### PR TITLE
Make nixfmt omnipotent^W idempotent

### DIFF
--- a/src/Nixfmt/Parser.hs
+++ b/src/Nixfmt/Parser.hs
@@ -27,10 +27,9 @@ import qualified Text.Megaparsec.Char.Lexer as L (decimal, float)
 
 import Nixfmt.Lexer (lexeme)
 import Nixfmt.Types
-  (Ann, Binder(..), Expression(..), File(..), Fixity(..), Leaf, ListPart(..),
-  Operator(..), ParamAttr(..), Parameter(..), Parser, Selector(..),
-  SimpleSelector(..), String, StringPart(..), Term(..), Token(..), operators,
-  tokenText)
+  (Ann, Binder(..), Expression(..), File(..), Fixity(..), Leaf, Operator(..),
+  ParamAttr(..), Parameter(..), Parser, Selector(..), SimpleSelector(..),
+  String, StringPart(..), Term(..), Token(..), operators, tokenText)
 import Nixfmt.Util
   (commonIndentation, identChar, manyP, manyText, pathChar, schemeChar, someP,
   someText, uriChar)
@@ -270,8 +269,7 @@ set = Set <$> optional (reserved KRec <|> reserved KLet) <*>
     symbol TBraceOpen <*> binders <*> symbol TBraceClose
 
 list :: Parser Term
-list = List <$> symbol TBrackOpen <*>
-    many (ListItem <$> term) <*> symbol TBrackClose
+list = List <$> symbol TBrackOpen <*> many term <*> symbol TBrackClose
 
 -- OPERATORS
 

--- a/src/Nixfmt/Types.hs
+++ b/src/Nixfmt/Types.hs
@@ -53,18 +53,12 @@ data Selector
 data Binder
     = Inherit Leaf (Maybe Term) [Leaf] Leaf
     | Assignment [Selector] Leaf Expression Leaf
-    | BinderTrivia Trivia
-    deriving (Show)
-
-data ListPart
-    = ListItem Term
-    | ListTrivia Trivia
     deriving (Show)
 
 data Term
     = Token Leaf
     | String String
-    | List Leaf [ListPart] Leaf
+    | List Leaf [Term] Leaf
     | Set (Maybe Leaf) Leaf [Binder] Leaf
     | Selection Term [Selector]
     | Parenthesized Leaf Expression Leaf


### PR DESCRIPTION
I've removed the special case of moving comments past commas for now.
I've indented comments that get moved before the in keyword for now,
that can be fixed after leading comments are actually stored with the
token they lead, rather than the previous token.

Fixes #23 