### PR TITLE
[OPS-934] Deploy website to AWS, add 404 page

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,6 +3,10 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
+env:
+  CDN_DISTRIBUTION_ID: E13UN1J1JFIWUZ
+  CDN_BUCKET: s3://nixfmt.serokell.io
+
 steps:
   - label: nix-build
     commands:
@@ -15,4 +19,8 @@ steps:
   - label: deploy web demo
     branches: master
     commands:
-      - nix-build -A nixfmt-webdemo --out-link /var/lib/buildkite-agent-public/cd/nixfmt-web
+      - nix-build -A nixfmt-webdemo
+      - nix run -f . awscli -c
+          aws s3 sync --delete result/ "$CDN_BUCKET"
+      - nix run -f . awscli -c
+          aws cloudfront create-invalidation --distribution-id "$CDN_DISTRIBUTION_ID" --paths '/*'

--- a/default.nix
+++ b/default.nix
@@ -45,7 +45,8 @@ in rec {
   nixfmt-js = ghcjsPackages.callCabal2nix "nixfmt" src { };
   nixfmt-webdemo = pkgs.runCommandNoCC "nixfmt-webdemo" { } ''
     mkdir $out
-    cp ${./js/index.html} $_/index.html
+    cp ${./js/index.html} $out/index.html
+    cp ${./js/404.html} $out/404.html
     cp ${nixfmt-js}/bin/js-interface.jsexe/{rts,lib,out,runmain}.js $out
     substituteInPlace $out/index.html --replace ../dist/build/js-interface/js-interface.jsexe/ ./
   '';

--- a/default.nix
+++ b/default.nix
@@ -56,4 +56,6 @@ in rec {
       stylish-haskell
     ]);
   });
+
+  inherit (pkgs) awscli;
 }

--- a/js/404.html
+++ b/js/404.html
@@ -1,0 +1,7 @@
+<!--
+© 2020 Serokell <hi@serokell.io>
+
+SPDX-License-Identifier: MPL-2.0
+-->
+
+404 Page Not Found


### PR DESCRIPTION
Analagous to ghc.dev setup: https://github.com/serokell/ghc.dev/blob/master/.buildkite/pipeline.yml

The pipeline needs proper AWS credentials to make it work