### PR TITLE
[OPS-984] Deployment: run `aws cp` before `aws sync` to replace existing files

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,6 +21,9 @@ steps:
     commands:
       - nix-build -A nixfmt-webdemo
       - nix run -f . awscli -c
-          aws s3 sync --delete result/ "$CDN_BUCKET"
+          aws s3 cp --recursive result/ "$CDN_BUCKET"
+      # delete files that don't exist anymore, use `--size-only` so behavior won't depend on local file timestamps
+      - nix run -f . awscli -c
+          aws s3 sync --delete --size-only result/ "$CDN_BUCKET"
       - nix run -f . awscli -c
           aws cloudfront create-invalidation --distribution-id "$CDN_DISTRIBUTION_ID" --paths '/*'


### PR DESCRIPTION
`aws s3 sync` compares file sizes and timestamps to decide if a file in
the bucket needs to be replaced, but all files in nix store have
timestamp=1. So if a new file happens to have the same size as the old
one, `aws s3 sync` would decide that it does not need to be updated.
Copy files to the local directory updating their timestamps to the
current time to fix it