### PR TITLE
Add pipefail on nixfmt-webdemo

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,7 +17,7 @@ steps:
       - nix-build -A packages.x86_64-linux.nixfmt-deriver | cachix push nixfmt
   - label: build web demo
     commands:
-      - nix-build -A packages.x86_64-linux.nixfmt-webdemo | cachix push nixfmt
+      - set -o pipefail; nix-build -A packages.x86_64-linux.nixfmt-webdemo | cachix push nixfmt
   - wait
   - label: deploy web demo
     branches: master


### PR DESCRIPTION
Buildkite was giving a passing status on broken nixfmt-webdemo builds. Try to fix this using pipefail.