### PR TITLE
Add default width length info in cli help

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -39,14 +39,24 @@ data Nixfmt = Nixfmt
     } deriving (Show, Data, Typeable)
 
 options :: Nixfmt
-options = Nixfmt
-    { files = [] &= args &= typ "FILES"
-    , width = 80 &= help "Maximum width in characters"
-    , check = False &= help "Check whether files are formatted"
-    , quiet = False &= help "Do not report errors"
-    , verify = False &= help "Check that the output parses and formats the same as the input"
-    } &= summary ("nixfmt v" ++ showVersion version)
-    &= help "Format Nix source code"
+options =
+  let defaultWidth = 80
+      addDefaultHint value message =
+        message ++ "\n[default: " ++ show value ++ "]"
+   in Nixfmt
+        { files = [] &= args &= typ "FILES"
+        , width =
+            defaultWidth &=
+            help (addDefaultHint defaultWidth "Maximum width in characters")
+        , check = False &= help "Check whether files are formatted"
+        , quiet = False &= help "Do not report errors"
+        , verify =
+            False &=
+            help
+              "Check that the output parses and formats the same as the input"
+        } &=
+      summary ("nixfmt v" ++ showVersion version) &=
+      help "Format Nix source code"
 
 data Target = Target
     { tDoRead :: IO Text


### PR DESCRIPTION
This PR adds the default number of maximum character width in the usage of the cli. Running

```bash
nixfmt --help
```

now prints

```
nixfmt v0.5.0

nixfmt [OPTIONS] [FILES]
  Format Nix source code

Common flags:
  -w --width=INT        Maximum width in characters
                        [default: 80]
  -c --check            Check whether files are formatted
  -q --quiet            Do not report errors
  -v --verify           Check that the output parses and formats the same as
                        the input
  -? --help             Display help message
  -V --version          Print version information
     --numeric-version  Print just the version number

```