### PR TITLE
floats: allow starting with ., prefer over int (nix compat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix nixfmt trying to allocate temp files that aren't used.
 * Nixfmt now accepts the '-' argument to read from stdin.
 * `nixfmt [dir]` now recursively formats nix files in that directory.
+* Float and int literal parsing now matches nix.
 
 ## 0.5.0 -- 2022-03-15
 

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -65,10 +65,14 @@ library
     Nixfmt
     Nixfmt.Lexer
     Nixfmt.Parser
+    Nixfmt.Parser.Float
     Nixfmt.Predoc
     Nixfmt.Pretty
     Nixfmt.Types
     Nixfmt.Util
+
+  default-extensions:
+    PackageImports
 
   other-extensions:
     DeriveFoldable
@@ -76,6 +80,7 @@ library
     FlexibleInstances
     LambdaCase
     OverloadedStrings
+    ScopedTypeVariables
     StandaloneDeriving
     TupleSections
 

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -83,6 +83,7 @@ library
   build-depends:
       base             >= 4.12.0 && < 4.17
     , megaparsec       >= 9.0.1 && < 9.3
+    , scientific       >= 0.3.0.0 && < 0.4.0.0
     , parser-combinators >= 1.0.3 && < 1.4
     , text             >= 1.2.3 && < 1.3
   default-language:    Haskell2010

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -83,8 +83,8 @@ library
   build-depends:
       base             >= 4.12.0 && < 4.17
     , megaparsec       >= 9.0.1 && < 9.3
-    , scientific       >= 0.3.0.0 && < 0.4.0.0
     , parser-combinators >= 1.0.3 && < 1.4
+    , scientific       >= 0.3.0 && < 0.4.0
     , text             >= 1.2.3 && < 1.3
   default-language:    Haskell2010
   ghc-options:

--- a/src/Nixfmt/Parser.hs
+++ b/src/Nixfmt/Parser.hs
@@ -4,25 +4,31 @@
  - SPDX-License-Identifier: MPL-2.0
  -}
 
-{-# LANGUAGE LambdaCase, OverloadedStrings #-}
+{-# LANGUAGE LambdaCase, OverloadedStrings, TypeFamilies, TypeApplications, ScopedTypeVariables #-}
 
 module Nixfmt.Parser where
 
 import Prelude hiding (String)
 
-import Control.Monad (guard, liftM2)
+import Data.Foldable (foldl')
+import Control.Monad (guard, liftM2, void)
 import Control.Monad.Combinators (sepBy)
 import qualified Control.Monad.Combinators.Expr as MPExpr
   (Operator(..), makeExprParser)
 import Data.Char (isAlpha)
+import qualified Data.Char as Char
+import Data.Proxy
 import Data.Foldable (toList)
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Text as Text (Text, cons, empty, singleton, split, stripPrefix)
 import Text.Megaparsec
-  (anySingle, chunk, eof, label, lookAhead, many, notFollowedBy, oneOf,
-  optional, satisfy, some, try, (<|>))
-import Text.Megaparsec.Char (char)
-import qualified Text.Megaparsec.Char.Lexer as L (decimal, float)
+  (anySingle, chunk, eof, label, lookAhead, many, notFollowedBy, oneOf, option,
+  chunkToTokens, takeWhile1P,
+  optional, satisfy, some, try, (<|>), (<?>), MonadParsec)
+import Text.Megaparsec.Char (char, char')
+import qualified Text.Megaparsec.Char.Lexer as L (decimal, signed)
+import qualified Text.Megaparsec as L (Token)
+import qualified Data.Scientific as Sci
 
 import Nixfmt.Lexer (lexeme)
 import Nixfmt.Types
@@ -64,8 +70,43 @@ reserved t = try $ lexeme $ rawSymbol t
 integer :: Parser (Ann Token)
 integer = ann Integer L.decimal
 
+-- copied (and modified) from Text.Megaparsec.Char.Lexer
+data SP = SP !Integer {-# UNPACK #-} !Int
+floatParse :: (MonadParsec e s m, L.Token s ~ Char, RealFloat a) => m a
+floatParse = do
+  c' <- (L.decimal <?> "decimal") <|> return 0
+  Sci.toRealFloat
+    <$> (( do
+              SP c e' <- dotDecimal_ c'
+              e <- option e' (try $ exponent_ e')
+              return (Sci.scientific c e)
+         )
+            <|> (Sci.scientific c' <$> exponent_ 0)
+        )
+{-# INLINE floatParse #-}
+
+-- copied from Text.Megaparsec.Char.Lexer
+dotDecimal_ :: forall e s m.
+  (MonadParsec e s m, L.Token s ~ Char) => Integer -> m SP
+dotDecimal_ c' = do
+  void (char '.')
+  let mkNum = foldl' step (SP c' 0) . chunkToTokens @s Proxy
+      step (SP a e') c =
+        SP
+          (a * 10 + fromIntegral (Char.digitToInt c))
+          (e' - 1)
+  mkNum <$> takeWhile1P (Just "digit") Char.isDigit
+{-# INLINE dotDecimal_ #-}
+
+-- copied from Text.Megaparsec.Char.Lexer
+exponent_ :: (MonadParsec e s m, L.Token s ~ Char) => Int -> m Int
+exponent_ e' = do
+  void (char' 'e')
+  (+ e') <$> L.signed (return ()) L.decimal
+{-# INLINE exponent_ #-}
+
 float :: Parser (Ann Token)
-float = ann Float L.float
+float = ann Float floatParse
 
 identifier :: Parser (Ann Token)
 identifier = ann Identifier $ do
@@ -227,7 +268,7 @@ selectorPath = (pure <$> selector Nothing) <>
 
 simpleTerm :: Parser Term
 simpleTerm = (String <$> string) <|> (Path <$> path) <|>
-    (Token <$> (envPath <|> float <|> integer <|> identifier)) <|>
+    (Token <$> (envPath <|> integer <|> float <|> identifier)) <|>
     parens <|> set <|> list
 
 term :: Parser Term

--- a/src/Nixfmt/Parser/Float.hs
+++ b/src/Nixfmt/Parser/Float.hs
@@ -1,0 +1,59 @@
+{- © 2022 Serokell <hi@serokell.io>
+ - © 2022 Lars Jellema <lars.jellema@gmail.com>
+ -
+ - SPDX-License-Identifier: MPL-2.0
+ -}
+
+{-# LANGUAGE TypeFamilies, TypeApplications, ScopedTypeVariables #-}
+
+module Nixfmt.Parser.Float (floatParse) where
+
+import "base" Data.Foldable (foldl')
+import "base" Data.Proxy (Proxy (..))
+import qualified "base" Data.Char as Char
+
+import "base" Control.Monad (void)
+import "megaparsec" Text.Megaparsec (
+    option, chunkToTokens, takeWhile1P, try,
+    (<|>), (<?>), MonadParsec, Token,
+  )
+import "megaparsec" Text.Megaparsec.Char.Lexer (decimal, signed)
+import "megaparsec" Text.Megaparsec.Char (char, char')
+
+import "scientific" Data.Scientific (toRealFloat, scientific)
+
+-- copied (and modified) from Text.Megaparsec.Char.Lexer
+data SP = SP !Integer {-# UNPACK #-} !Int
+floatParse :: (MonadParsec e s m, Token s ~ Char, RealFloat a) => m a
+floatParse = do
+  c' <- (decimal <?> "decimal") <|> return 0
+  toRealFloat
+    <$> (( do
+              SP c e' <- dotDecimal_ c'
+              e <- option e' (try $ exponent_ e')
+              return (scientific c e)
+         )
+            <|> (scientific c' <$> exponent_ 0)
+        )
+{-# INLINE floatParse #-}
+
+-- copied from Text.Megaparsec.Char.Lexer
+dotDecimal_ :: forall e s m.
+  (MonadParsec e s m, Token s ~ Char) => Integer -> m SP
+dotDecimal_ c' = do
+  void (char '.')
+  let mkNum = foldl' step (SP c' 0) . chunkToTokens @s Proxy
+      step (SP a e') c =
+        SP
+          (a * 10 + fromIntegral (Char.digitToInt c))
+          (e' - 1)
+  mkNum <$> takeWhile1P (Just "digit") Char.isDigit
+{-# INLINE dotDecimal_ #-}
+
+-- copied from Text.Megaparsec.Char.Lexer
+exponent_ :: (MonadParsec e s m, Token s ~ Char) => Int -> m Int
+exponent_ e' = do
+  void (char' 'e')
+  (+ e') <$> signed (return ()) decimal
+{-# INLINE exponent_ #-}
+


### PR DESCRIPTION
Fixes #98, #86, #85

I'm very unhappy over having to copy this much code from megaparsec, but it doesn't export it. See https://hackage.haskell.org/package/megaparsec-9.2.2/docs/src/Text.Megaparsec.Char.Lexer.html#float

Not sure about the version bounds on scientific.