### PR TITLE
Add a pre-commit hook for nixfmt with `nix run`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -8,7 +8,7 @@
 
 - id: &id-nix nixfmt-nix
   name: *id-nix
-  entry: nix --extra-experimental-features "flakes nix-command" run nixpkgs#nixfmt-rfc-style
+  entry: nix --extra-experimental-features "flakes nix-command" run nixpkgs#nixfmt
   language: system
   types:
     - nix


### PR DESCRIPTION
The pre-commit hook for `nixfmt` currently relies on `cabal` being installed on the user's system, which might not always be available.

This MR adds another hook (`nixfmt-nix`) that instead uses `nix run` to provide the formatting functionality.

Please let me know if this is not within this project's scope. 