### PR TITLE
Reformat indented strings to simple strings when appropriate

### DIFF
--- a/standard.md
+++ b/standard.md
@@ -327,6 +327,10 @@ For list elements, attributes, and function arguments, the following applies:
 ### Strings
 
 - The kind of quotes used in strings (`"` vs `''`) must be preserved from the input.
+  - Exception: Indented strings (`''...''`) that contain no newlines, double quote characters or backslashes are automatically reformatted as simple strings (`"..."`).
+  - When converting indented strings to simple strings, escape sequences are rewritten to maintain semantic equivalence:
+    - `''$` becomes `\$` (escaped dollar sign)
+    - `'''` becomes `''` (quotes)
 - The non-interpolated string parts must be preserved from the input
   - E.g. changing `\t` to a tab character must not be done automatically
 
@@ -343,6 +347,22 @@ For list elements, attributes, and function arguments, the following applies:
 ''
   This is a really long string that would not fit within the line length limit
 ''
+
+# Indented strings with simple content get reformatted as simple strings
+''hello''        # becomes "hello"
+''hello world''  # becomes "hello world"
+
+# Escape sequences are rewritten when converting to simple strings
+''''${pkgs.ghostscript}/bin/ps2pdf''  # becomes "\${pkgs.ghostscript}/bin/ps2pdf"
+'''test''$var''                        # becomes "'test\$var"
+'''can''t'''                          # becomes "'can't"
+
+# But these stay as indented strings
+''
+  hello
+  world
+''
+''hello "quoted" text''
 ```
 
 #### Interpolations

--- a/test/correct/indented-string.nix
+++ b/test/correct/indented-string.nix
@@ -9,6 +9,6 @@
     $'\t'
   ''
 
-  ''ending dollar $''
-  ''$''
+  ''"ending dollar $''
+  ''"$''
 ]

--- a/test/diff/idioms_nixos_2/in.nix
+++ b/test/diff/idioms_nixos_2/in.nix
@@ -734,6 +734,7 @@ in {
 
     { assertions = [
       { assertion = cfg.database.createLocally -> cfg.config.dbtype == "mysql";
+        # single line idented strings must be reformatted to simple strings 
         message = ''services.nextcloud.config.dbtype must be set to mysql if services.nextcloud.database.createLocally is set to true.'';
       }
     ]; }

--- a/test/diff/idioms_nixos_2/out-pure.nix
+++ b/test/diff/idioms_nixos_2/out-pure.nix
@@ -794,7 +794,8 @@ in
       assertions = [
         {
           assertion = cfg.database.createLocally -> cfg.config.dbtype == "mysql";
-          message = ''services.nextcloud.config.dbtype must be set to mysql if services.nextcloud.database.createLocally is set to true.'';
+          # single line idented strings must be reformatted to simple strings
+          message = "services.nextcloud.config.dbtype must be set to mysql if services.nextcloud.database.createLocally is set to true.";
         }
       ];
     }

--- a/test/diff/idioms_nixos_2/out.nix
+++ b/test/diff/idioms_nixos_2/out.nix
@@ -796,7 +796,8 @@ in
       assertions = [
         {
           assertion = cfg.database.createLocally -> cfg.config.dbtype == "mysql";
-          message = ''services.nextcloud.config.dbtype must be set to mysql if services.nextcloud.database.createLocally is set to true.'';
+          # single line idented strings must be reformatted to simple strings
+          message = "services.nextcloud.config.dbtype must be set to mysql if services.nextcloud.database.createLocally is set to true.";
         }
       ];
     }

--- a/test/diff/string/in.nix
+++ b/test/diff/string/in.nix
@@ -92,4 +92,10 @@
   "--${
     "test"
   }"
+  ''''${pkgs.ghostscript}/bin/ps2pdf''
+  '''test''$test''
+  '''test'''quotes''
+  '''plain''
+  '' between spaces ''
+  '' !#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~''
 ]

--- a/test/diff/string/out-pure.nix
+++ b/test/diff/string/out-pure.nix
@@ -13,11 +13,11 @@
    b
   "
   ###
-  ''''
+  ""
   ###
-  ''a''
+  "a"
   ###
-  ''${""}''
+  "${""}"
   ###
   ''
     ${""}
@@ -51,7 +51,7 @@
        e
   ''
   ###
-  ''''
+  ""
   ###
   ''
     declare -a makefiles=(./*.mak)
@@ -66,7 +66,7 @@
     [${mkSectionName sectName}]
   ''
   ###
-  ''-couch_ini ${cfg.package}/etc/default.ini ${configFile} ${pkgs.writeText "couchdb-extra.ini" cfg.extraConfig} ${cfg.configFile}''
+  "-couch_ini ${cfg.package}/etc/default.ini ${configFile} ${pkgs.writeText "couchdb-extra.ini" cfg.extraConfig} ${cfg.configFile}"
   ###
   ''exec i3-input -F "mark %s" -l 1 -P 'Mark: ' ''
   ###
@@ -74,7 +74,7 @@
   ###
   ''"${pkgs.name or "<unknown-name>"}";''
   ###
-  ''${pkgs.replace-secret}/bin/replace-secret '${placeholder}' '${secretFile}' '${targetFile}' ''
+  "${pkgs.replace-secret}/bin/replace-secret '${placeholder}' '${secretFile}' '${targetFile}' "
   ###
   ''
     mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
@@ -92,4 +92,10 @@
   ''
 
   "--${"test"}"
+  "\${pkgs.ghostscript}/bin/ps2pdf"
+  "'test\$test"
+  "'test''quotes"
+  "'plain"
+  "between spaces "
+  "!#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 ]

--- a/test/diff/string/out.nix
+++ b/test/diff/string/out.nix
@@ -13,11 +13,11 @@
    b
   "
   ###
-  ''''
+  ""
   ###
-  ''a''
+  "a"
   ###
-  ''${""}''
+  "${""}"
   ###
   ''
     ${""}
@@ -51,7 +51,7 @@
        e
   ''
   ###
-  ''''
+  ""
   ###
   ''
     declare -a makefiles=(./*.mak)
@@ -66,7 +66,7 @@
     [${mkSectionName sectName}]
   ''
   ###
-  ''-couch_ini ${cfg.package}/etc/default.ini ${configFile} ${pkgs.writeText "couchdb-extra.ini" cfg.extraConfig} ${cfg.configFile}''
+  "-couch_ini ${cfg.package}/etc/default.ini ${configFile} ${pkgs.writeText "couchdb-extra.ini" cfg.extraConfig} ${cfg.configFile}"
   ###
   ''exec i3-input -F "mark %s" -l 1 -P 'Mark: ' ''
   ###
@@ -74,7 +74,7 @@
   ###
   ''"${pkgs.name or "<unknown-name>"}";''
   ###
-  ''${pkgs.replace-secret}/bin/replace-secret '${placeholder}' '${secretFile}' '${targetFile}' ''
+  "${pkgs.replace-secret}/bin/replace-secret '${placeholder}' '${secretFile}' '${targetFile}' "
   ###
   ''
     mkdir -p "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
@@ -92,4 +92,10 @@
   ''
 
   "--${"test"}"
+  "\${pkgs.ghostscript}/bin/ps2pdf"
+  "'test\$test"
+  "'test''quotes"
+  "'plain"
+  "between spaces "
+  "!#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_`abcdefghijklmnopqrstuvwxyz{|}~"
 ]

--- a/test/diff/string_interpol/out-pure.nix
+++ b/test/diff/string_interpol/out-pure.nix
@@ -2,9 +2,9 @@
   "${
     /* a */ "${/* b */ "${c}"}" # d
   }"
-  ''${
-    /* a */ ''${/* b */ ''${c}''}'' # d
-  }''
+  "${
+    /* a */ "${/* b */ "${c}"}" # d
+  }"
   {
     ExecStart = "${pkgs.openarena}/bin/oa_ded +set fs_basepath ${pkgs.openarena}/openarena-0.8.8 +set fs_homepath /var/lib/openarena ${
       concatMapStringsSep (x: x) " " cfg.extraFlags

--- a/test/diff/string_interpol/out.nix
+++ b/test/diff/string_interpol/out.nix
@@ -2,9 +2,9 @@
   "${
     /* a */ "${/* b */ "${c}"}" # d
   }"
-  ''${
-    /* a */ ''${/* b */ ''${c}''}'' # d
-  }''
+  "${
+    /* a */ "${/* b */ "${c}"}" # d
+  }"
   {
     ExecStart = "${pkgs.openarena}/bin/oa_ded +set fs_basepath ${pkgs.openarena}/openarena-0.8.8 +set fs_homepath /var/lib/openarena ${
       concatMapStringsSep (x: x) " " cfg.extraFlags


### PR DESCRIPTION
Converts indented strings to simple strings when they contain no newlines, quotes, or backslashes. For example: ''hello'' becomes "hello" and ''path/to/file'' becomes "path/to/file".

Also handles escape sequence conversion (''$ -> \$ and ''' -> '') and updates standard.md to document this behavior.

closes #274 