### PR TITLE
Add nixfmt-static package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -56,11 +56,14 @@ let
     );
   };
 
-  build = lib.pipe pkgs.haskellPackages.nixfmt [
+  haskellBuildPipeline = [
     haskell.lib.justStaticExecutables
     haskell.lib.dontHaddock
     (drv: lib.lazyDerivation { derivation = drv; })
   ];
+
+  build = lib.pipe pkgs.haskellPackages.nixfmt haskellBuildPipeline;
+  buildStatic = lib.pipe pkgs.pkgsStatic.haskellPackages.nixfmt haskellBuildPipeline;
 
   treefmtEval = (import sources.treefmt-nix).evalModule pkgs {
     # Used to find the project root
@@ -114,7 +117,10 @@ let
 in
 build
 // {
-  packages.nixfmt = build;
+  packages = {
+    nixfmt = build;
+    nixfmt-static = buildStatic;
+  };
 
   inherit pkgs;
 


### PR DESCRIPTION
Added: `nix build .#nixfmt-static`

This adds the `nixfmt-static` package, which provides a statically linked `nixfmt` binary (built with musl for a smaller size).
It’s especially useful for tools like [[mason.nvim](https://github.com/mason-org/mason.nvim)], as it makes static binaries available for project releases across all distributions.

Let me know if I should include it in the GitHub pipelines.
Also, it would be great if we could add the binary to the current release!