### PR TITLE
some improvements wrt memory behaviour (and thus time behaviour, too) 

### DIFF
--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -80,6 +80,7 @@ library
   hs-source-dirs:      src
   build-depends:
       base             >= 4.12.0
+    , containers
     , megaparsec       >= 9.0.1 && < 9.6
     , mtl
     , parser-combinators >= 1.0.3 && < 1.4

--- a/src/Nixfmt.hs
+++ b/src/Nixfmt.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Nixfmt (

--- a/src/Nixfmt/Types.hs
+++ b/src/Nixfmt/Types.hs
@@ -3,9 +3,11 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StrictData #-}
 
 module Nixfmt.Types (
   ParseErrorBundle,
@@ -52,6 +54,7 @@ import Data.Foldable (toList)
 import Data.Function (on)
 import Data.List.NonEmpty as NonEmpty
 import Data.Maybe (maybeToList)
+import Data.Sequence
 import Data.Text (Text)
 import Data.Void (Void)
 import Text.Megaparsec (Pos)
@@ -76,7 +79,7 @@ data Trivium
     LanguageAnnotation Text
   deriving (Eq, Show)
 
-type Trivia = [Trivium]
+type Trivia = Seq Trivium
 
 newtype TrailingComment = TrailingComment Text deriving (Eq, Show)
 
@@ -124,7 +127,7 @@ instance (Eq a) => Eq (Ann a) where
 
 data Item a
   = -- | An item
-    Item a
+    Item !a
   | -- | Trivia interleaved in items
     Comments Trivia
   deriving (Foldable, Show, Functor)


### PR DESCRIPTION
I've tested this mainly on nixpkgs' hackage-packages.nix which is a quite large expression.
Previously: 
<img width="1527" height="1342" alt="image" src="https://github.com/user-attachments/assets/1c3a7a48-96af-479a-aac5-164e79a6213a" />

After removing some retainers: 
<img width="1527" height="1342" alt="image" src="https://github.com/user-attachments/assets/128bc897-f10a-4ccc-8c7c-7b67c28fe79a" />

Runtime: 41s -> 13.7s (reduction by 2/3) 
Max residency: 750 Mb -> 380 Mb

As you can see, the largest space leaks (in the parser) are fixed, but the pretty printer still uses lazy lists rather recklessly so there's still a huge space leak (caused by list constructors) which I think, I will be able to fix, too, but I do not have more time tonight. 

This work was kindly made possible by well-typed. 