### PR TITLE
[#351] Fix parser for chained prefix operators

### DIFF
--- a/test/diff/operator-after-operator/in.nix
+++ b/test/diff/operator-after-operator/in.nix
@@ -1,3 +1,22 @@
-# https://github.com/NixOS/nixfmt/issues/122
-(1+/**/1)
-(1+.4)
+[
+  # https://github.com/NixOS/nixfmt/issues/122
+  (1+/**/1)
+  (1+.4)
+  # https://github.com/NixOS/nixfmt/issues/351
+  (--1)
+  (- - 1)
+  (-- 1)
+  (- -1)
+  (---1)
+  (-- -1)
+  (- --1)
+  (-- --1)
+  (!!a)
+  (! ! a)
+  (!! a)
+  (! !a)
+  (!!!a)
+  (!! !a)
+  (! !!a)
+  (!! !!a)
+]

--- a/test/diff/operator-after-operator/out-pure.nix
+++ b/test/diff/operator-after-operator/out-pure.nix
@@ -1,2 +1,22 @@
-# https://github.com/NixOS/nixfmt/issues/122
-(1 + 1) (1 + .4)
+[
+  # https://github.com/NixOS/nixfmt/issues/122
+  (1 + 1)
+  (1 + .4)
+  # https://github.com/NixOS/nixfmt/issues/351
+  (--1)
+  (--1)
+  (--1)
+  (--1)
+  (---1)
+  (---1)
+  (---1)
+  (----1)
+  (!!a)
+  (!!a)
+  (!!a)
+  (!!a)
+  (!!!a)
+  (!!!a)
+  (!!!a)
+  (!!!!a)
+]

--- a/test/diff/operator-after-operator/out.nix
+++ b/test/diff/operator-after-operator/out.nix
@@ -1,2 +1,22 @@
-# https://github.com/NixOS/nixfmt/issues/122
-(1 + 1) (1 + .4)
+[
+  # https://github.com/NixOS/nixfmt/issues/122
+  (1 + 1)
+  (1 + .4)
+  # https://github.com/NixOS/nixfmt/issues/351
+  (--1)
+  (--1)
+  (--1)
+  (--1)
+  (---1)
+  (---1)
+  (---1)
+  (----1)
+  (!!a)
+  (!!a)
+  (!!a)
+  (!!a)
+  (!!!a)
+  (!!!a)
+  (!!!a)
+  (!!!!a)
+]


### PR DESCRIPTION
Fix a bug where nixfmt would reject expressions with multiple prefix operators (numerical negation `-` and boolean inversion `!`), even though this is valid Nix syntax.  Closes #351 