### PR TITLE
Add automated CI workflow for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release on Version Change
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'nixfmt.cabal'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release-if-version-changed:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # need previous commit for comparison
+
+      - name: Get version from nixfmt.cabal
+        id: get_version
+        run: |
+          CABAL_FILE="nixfmt.cabal"
+
+          # Extract the version
+          VERSION=$(grep -m1 "^version:" $CABAL_FILE | awk '{print $2}')
+          echo "Version found in cabal: $VERSION"
+
+          # Get previous version from last commit
+          PREV_VERSION=$(git show HEAD~1:"$CABAL_FILE" | grep -m1 "^version:" | awk '{print $2}')
+          echo "Previous version: $PREV_VERSION"
+
+          # Export for later steps
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "prev_version=$PREV_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if version changed
+        id: compare
+        env:
+          PREV_VERSION: ${{ steps.get_version.outputs.prev_version }}
+          VERSION: ${{ steps.get_version.outputs.version }}
+        run: |
+          if [ "$PREV_VERSION" != "$VERSION" ]; then
+            echo "version_changed=true" >> $GITHUB_ENV
+            echo "::notice ::✅ Version changed from $PREV_VERSION to $VERSION"
+          else
+            echo "version_changed=false" >> $GITHUB_ENV
+            echo "::notice ::Version did not change, skipping release"
+          fi
+      - name: Extract changelog section for current version
+        if: ${{ env.version_changed == 'true' }}
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+        run: |
+          echo "Extracting changelog section for version $VERSION"
+
+          # Extract everything after the "## <version>" header until the next "## "
+          awk -v ver="$VERSION" '
+            $0 ~ "^##[[:space:]]+" ver {found=1; next}
+            found && /^##[[:space:]]+/ {exit}
+            found
+          ' CHANGELOG.md > RELEASE_NOTES.md
+
+          if [ ! -s RELEASE_NOTES.md ]; then
+            echo "::error ::⚠️ No changelog section found for version $VERSION"
+            echo "(Make sure you have a header like '## $VERSION -- YYYY-MM-DD')"
+            echo "- No notes will be attached to the release -"
+            echo "No changelog section found for version $VERSION." > RELEASE_NOTES.md
+            exit 1
+          fi
+
+          echo "---- Extracted Changelog ----"
+          cat RELEASE_NOTES.md
+          echo "--------------------------"
+
+      - name: Setup Nix
+        if: ${{ env.version_changed == 'true' }}
+        uses: cachix/install-nix-action@v26
+
+      - name: Setup Cachix cache
+        if: ${{ env.version_changed == 'true' }}
+        uses: cachix/cachix-action@v14
+        with:
+          name: nixos-nixfmt
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+      - name: Build static binary
+        if: ${{ env.version_changed == 'true' }}
+        run: |
+          nix-build -A packages.nixfmt-static
+
+      - name: Create GitHub Release
+        if: ${{ env.version_changed == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: "${{ steps.get_version.outputs.version }}"
+        run:
+          gh release create v$VERSION ./result/bin/nixfmt --title "v$VERSION" --notes-file RELEASE_NOTES.md 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -8,4 +8,4 @@ rather than the version from the cabalfile.
 - Bump the version in the [cabal file](./nixfmt.cabal)
 - Update the [changelog](./CHANGELOG.md) with the new version
 - Create a PR with the above changes and merge it
-- Create a [new GitHub release](https://github.com/NixOS/nixfmt/releases/new) with tag matching the version and set the release notes to this versions changelog
+- After a successful build, a [new GitHub release](https://github.com/NixOS/nixfmt/releases) will automatically be created, along with a tag matching the version, via a GitHub Actions workflow. Keep an eye on the process to ensure everything runs smoothly!


### PR DESCRIPTION
Follow up PR after #349 

Added CI workflow that triggers when a version change is pushed (in nixfmt.cabal) to the master branch.
It automatically builds a static binary, tags the commit, and creates a GitHub release with notes pulled from CHANGELOG.md.

Example release: https://github.com/FlashOnFire/nixfmt/releases/tag/v4.1.0

Edit:
Just thought that, as an alternative, we could have a workflow that triggers when a release is published and simply appends the static binary to it. That way we can keep the release process as-is.
Let me know which option you prefer.