### PR TITLE
Fix language annotations inside lists on function arguments

### DIFF
--- a/test/diff/language-annotation/in.nix
+++ b/test/diff/language-annotation/in.nix
@@ -70,6 +70,18 @@
     "console.log('Script 4');"
   ];
 
+  # Language annotation in list on function argument
+  runScripts = (lib.mkSomething [
+    /* bash */ ''
+      echo "Script A"
+    ''
+  ][
+    /* python */ ''
+      print("Script B")
+    ''
+      /* ruby */ "puts 'Script C'"
+  ]);
+
   aboveString = 
     /* bash */
     "echo 'Above string'";

--- a/test/diff/language-annotation/out-pure.nix
+++ b/test/diff/language-annotation/out-pure.nix
@@ -74,6 +74,22 @@
     /* js */ "console.log('Script 4');"
   ];
 
+  # Language annotation in list on function argument
+  runScripts = (
+    lib.mkSomething
+      [
+        /* bash */ ''
+          echo "Script A"
+        ''
+      ]
+      [
+        /* python */ ''
+          print("Script B")
+        ''
+        /* ruby */ "puts 'Script C'"
+      ]
+  );
+
   aboveString = /* bash */ "echo 'Above string'";
 
   # Language annotation in attribute set

--- a/test/diff/language-annotation/out.nix
+++ b/test/diff/language-annotation/out.nix
@@ -74,6 +74,22 @@
     /* js */ "console.log('Script 4');"
   ];
 
+  # Language annotation in list on function argument
+  runScripts = (
+    lib.mkSomething
+      [
+        /* bash */ ''
+          echo "Script A"
+        ''
+      ]
+      [
+        /* python */ ''
+          print("Script B")
+        ''
+        /* ruby */ "puts 'Script C'"
+      ]
+  );
+
   aboveString = /* bash */ "echo 'Above string'";
 
   # Language annotation in attribute set


### PR DESCRIPTION
I noticed this while working on #353

list rendering code inside function arguments has special handling and was not considering language annotations.

This ensures the language annotations are formatted as intended on this case.

Before:
```nix
  runScripts = (
    lib.mkSomething
      [
        /* bash */
        ''
          echo "Script A"
        ''
      ]
      [
        /* python */
        ''
          print("Script B")
        ''
        /* ruby */
        "puts 'Script C'"
      ]
  );
```

Now:
```nix
  runScripts = (
    lib.mkSomething
      [
        /* bash */ ''
          echo "Script A"
        ''
      ]
      [
        /* python */ ''
          print("Script B")
        ''
        /* ruby */ "puts 'Script C'"
      ]
  );
```