### PR TITLE
Add a flake formatter (so `nix fmt` works)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -140,4 +140,6 @@ build
   inherit checks;
 
   ci = pkgs.linkFarm "ci" checks;
+
+  treefmt = treefmtEval.config.build.wrapper;
 }

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,8 @@
         checks = result.checks;
 
         devShells.default = result.shell;
+
+        formatter = result.treefmt;
       }
     );
 }


### PR DESCRIPTION
I have my editor configured to run `nix fmt` on files I edit, so this is quite helpful for me.