### PR TITLE
Implement treefmt's stdin spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,9 +291,9 @@ to return back to the unmerged state.
 
 ## Usage
 
-* `nixfmt < input.nix` – reads Nix code from `stdin`, formats it, and outputs to `stdout`
+* `echo "{a=1;}" | nixfmt --stdin-filepath input.nix` – reads Nix code from `stdin`, formats it, and outputs to `stdout` (the filepath (`input.nix`) is only used for error messages)
 * `nixfmt file.nix` – format the file in place
 
-## Acknowledgements
+## Acknowledgments
 
 `nixfmt` was originally developed by [Serokell](https://github.com/serokell) and later donated to become an official Nix project with the acceptance of [RFC 166](https://github.com/NixOS/rfcs/pull/166).


### PR DESCRIPTION
Full disclosure: the treefmt stdin spec is not yet finalized (see https://github.com/numtide/treefmt/pull/586). However, nothing prevents us from implementing the version of it that I hope will be approved.

This completes https://github.com/NixOS/nixfmt/issues/305.

I have very little haskell knowledge. I'm sure there are issues with this implementation. Be kind, I'm excited to learn more!