### PR TITLE
Fix empty lists/sets with comments idempotency

### DIFF
--- a/test/diff/attr_set/in.nix
+++ b/test/diff/attr_set/in.nix
@@ -327,6 +327,61 @@
       ++ baz # newline!
       ++ meow;
 
+    # https://github.com/NixOS/nixfmt/issues/362
+    foobar = [ /* foobar */ ];
+
+    foobar =
+      [
+        # foobar
+      ];
+
+    foobar =
+    [ # foobar
+    ];
+
+    foobar =
+      [ # foobar
+      ];
+
+    foobar = [
+      # foobar
+    ];
+
+    foobar2 = [ /* foobar */
+
+     ];
+
+    foobar3 = [
+
+       /* foobar */ ];
+
+    foobar = { /* foobar */ };
+
+    foobar =
+      {
+        # foobar
+      };
+
+    foobar =
+    { # foobar
+    };
+
+    foobar =
+      { # foobar
+      };
+
+    foobar = {
+      # foobar
+    };
+
+    foobar2 = { /* foobar */
+
+     };
+
+    foobar3 = {
+
+       /* foobar */ };
+
     environment.systemPackages =
       # Include the PAM modules in the system path mostly for the manpages.
       [ package ]

--- a/test/diff/attr_set/out-pure.nix
+++ b/test/diff/attr_set/out-pure.nix
@@ -432,6 +432,67 @@
       ++ baz # newline!
       ++ meow;
 
+    # https://github.com/NixOS/nixfmt/issues/362
+    foobar = [
+      # foobar
+    ];
+
+    foobar = [
+      # foobar
+    ];
+
+    foobar = [
+      # foobar
+    ];
+
+    foobar = [
+      # foobar
+    ];
+
+    foobar = [
+      # foobar
+    ];
+
+    foobar2 = [
+      # foobar
+
+    ];
+
+    foobar3 = [
+
+      # foobar
+    ];
+
+    foobar = {
+      # foobar
+    };
+
+    foobar = {
+      # foobar
+    };
+
+    foobar = {
+      # foobar
+    };
+
+    foobar = {
+      # foobar
+    };
+
+    foobar = {
+      # foobar
+    };
+
+    foobar2 = {
+      # foobar
+
+    };
+
+    foobar3 = {
+
+      # foobar
+    };
+
     environment.systemPackages =
       # Include the PAM modules in the system path mostly for the manpages.
       [ package ] ++ lib.optional config.users.ldap.enable pam_ldap;

--- a/test/diff/attr_set/out.nix
+++ b/test/diff/attr_set/out.nix
@@ -449,6 +449,67 @@
       ++ baz # newline!
       ++ meow;
 
+    # https://github.com/NixOS/nixfmt/issues/362
+    foobar = [
+      # foobar
+    ];
+
+    foobar = [
+      # foobar
+    ];
+
+    foobar = [
+      # foobar
+    ];
+
+    foobar = [
+      # foobar
+    ];
+
+    foobar = [
+      # foobar
+    ];
+
+    foobar2 = [
+      # foobar
+
+    ];
+
+    foobar3 = [
+
+      # foobar
+    ];
+
+    foobar = {
+      # foobar
+    };
+
+    foobar = {
+      # foobar
+    };
+
+    foobar = {
+      # foobar
+    };
+
+    foobar = {
+      # foobar
+    };
+
+    foobar = {
+      # foobar
+    };
+
+    foobar2 = {
+      # foobar
+
+    };
+
+    foobar3 = {
+
+      # foobar
+    };
+
     environment.systemPackages =
       # Include the PAM modules in the system path mostly for the manpages.
       [ package ] ++ lib.optional config.users.ldap.enable pam_ldap;

--- a/test/diff/lists/in.nix
+++ b/test/diff/lists/in.nix
@@ -82,6 +82,15 @@
 
   ]
 
+  [ /* foobar */ ]
+
+  [ # foobar
+  ]
+
+  [
+    # foobar
+  ]
+
 
   [ [ multi line ] ]
   [ [ [ singleton ] ] ]

--- a/test/diff/lists/out-pure.nix
+++ b/test/diff/lists/out-pure.nix
@@ -109,6 +109,18 @@
   ]
 
   [
+    # foobar
+  ]
+
+  [
+    # foobar
+  ]
+
+  [
+    # foobar
+  ]
+
+  [
     [
       multi
       line

--- a/test/diff/lists/out.nix
+++ b/test/diff/lists/out.nix
@@ -112,6 +112,18 @@
   ]
 
   [
+    # foobar
+  ]
+
+  [
+    # foobar
+  ]
+
+  [
+    # foobar
+  ]
+
+  [
     [
       multi
       line


### PR DESCRIPTION
Empty lists and attribute sets containing only comments were not formatting idempotently. The issue occurred because block comments (/* ... */) initially parsed as trailing comments on the opening bracket would convert to line comments (# ...) and move inside the Items during formatting. This AST structure change caused different rendering behavior between successive runs.

Fixed by ensuring consistent handling of both states:
- Modified `renderList` to use `hardline` separator when items contain only comments or when the opening bracket has trivia or the opening bracket has 
- Updated `isAbsorbable` to treat lists/sets with trivia or only comments as absorbable in assignments

This ensures the same formatting output regardless of whether comments still are trailing comments for the opening brackets or have already been converted to list comment items.

fixes #362