### PR TITLE
Add deprecation warning for bare invocation of nixfmt

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -169,6 +169,9 @@ checkFileTarget :: FilePath -> Target
 checkFileTarget path = Target (readFileUtf8 path) path (const $ const $ pure ())
 
 toTargets :: Nixfmt -> IO [Target]
+toTargets Nixfmt{files = [], filename = Nothing} = do
+  hPutStrLn stderr "\ESC[33mWarning: Bare invocation of nixfmt is deprecated. Use 'nixfmt -' for anonymous stdin.\ESC[0m"
+  pure [stdioTarget Nothing]
 toTargets Nixfmt{files = [], filename} = pure [stdioTarget filename]
 toTargets Nixfmt{files = ["-"], filename} = pure [stdioTarget filename]
 toTargets Nixfmt{check = False, files = paths} = map fileTarget <$> collectAllNixFiles paths

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -170,7 +170,7 @@ checkFileTarget path = Target (readFileUtf8 path) path (const $ const $ pure ())
 
 toTargets :: Nixfmt -> IO [Target]
 toTargets Nixfmt{files = [], filename = Nothing} = do
-  hPutStrLn stderr "\ESC[33mWarning: Bare invocation of nixfmt is deprecated. Use 'nixfmt -' for anonymous stdin.\ESC[0m"
+  hPutStrLn stderr "\ESC[33mWarning: Bare invocation of nixfmt is deprecated. Use 'nixfmt -' for anonymous stdin.\ESC[39m"
   pure [stdioTarget Nothing]
 toTargets Nixfmt{files = [], filename} = pure [stdioTarget filename]
 toTargets Nixfmt{files = ["-"], filename} = pure [stdioTarget filename]


### PR DESCRIPTION
Added warning: `Bare invocation of nixfmt is deprecated. Use 'nixfmt -' for anonymous stdin.`

This closes #301 