### PR TITLE
Fix spelling mistakes in comments, changelog, and test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Other than the above, there are some notable UX changes:
   - A [Git mergetool mode](https://github.com/nixos/nixfmt?tab=readme-ov-file#git-mergetool) is now supported.
 - CLI changes:
   - In stdin-mode, `--filename <path>` can now be used to specify a filename for diagnostics.
-  - Number of indendation spaces can now be configured using `--indent <number>`
+  - Number of indentation spaces can now be configured using `--indent <number>`
 
 ## 0.6.0 -- 2023-10-31
 

--- a/main/System/IO/Atomic.hs
+++ b/main/System/IO/Atomic.hs
@@ -43,7 +43,7 @@ withOutputFile path act = transact begin commit rollback $ \(tpath, th) -> do
     begin :: IO (FilePath, Handle)
     begin = openTempFileWithDefaultPermissions tmpDir tmpTemplate
 
-    -- TODO: Support for non-unix platofrms.
+    -- TODO: Support for non-unix platforms.
     -- TODO: Preserve ctime?
     -- TODO: Preserve extended attributes (ACLs, ...)?
     copyAttributes :: (FilePath, Handle) -> IO ()

--- a/src/Nixfmt/Predoc.hs
+++ b/src/Nixfmt/Predoc.hs
@@ -400,7 +400,7 @@ textWidth = Text.length
 
 -- | Attempt to fit a list of documents in a single line of a specific width.
 -- ni — next indentation. Only used for trailing comment calculations. Set this to the indentation
---      of the next line relative to the current one. So usuall 2 when the indentation level increases, 0 otherwise.
+--      of the next line relative to the current one. So usually 2 when the indentation level increases, 0 otherwise.
 -- c — allowed width
 fits :: Int -> Int -> Doc -> Maybe Text
 fits _ c _ | c < 0 = Nothing

--- a/src/Nixfmt/Pretty.hs
+++ b/src/Nixfmt/Pretty.hs
@@ -352,7 +352,7 @@ moveParamsComments
     [ ParamAttr name maybeDefault (Just (comma{preTrivia = []})),
       ParamEllipsis (ellipsis{preTrivia = trivia <> trivia'})
     ]
--- Inject a trailing comma on the last element if nessecary
+-- Inject a trailing comma on the last element if necessary
 moveParamsComments [ParamAttr name@Ann{sourceLine} def Nothing] = [ParamAttr name def (Just (ann sourceLine TComma))]
 moveParamsComments (x : xs) = x : moveParamsComments xs
 moveParamsComments [] = []

--- a/src/Nixfmt/Types.hs
+++ b/src/Nixfmt/Types.hs
@@ -203,7 +203,7 @@ instance Eq Parameter where
       && cmp l2 r2
       && l3 == r3
     where
-      -- Compare two lists of paramters, but for the last argument don't compare whether or not there is a trailing comma
+      -- Compare two lists of parameters, but for the last argument don't compare whether or not there is a trailing comma
       cmp [] [] = True
       cmp [ParamAttr x1 x2 _] [ParamAttr y1 y2 _] = x1 == y1 && x2 == y2
       cmp (x : xs) (y : ys) = x == y && cmp xs ys

--- a/test/diff/idioms_lib_5/in.nix
+++ b/test/diff/idioms_lib_5/in.nix
@@ -62,7 +62,7 @@ let
 
   isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or []) != [];
 
-  # Alow granular checks to allow only some unfree packages
+  # Allow granular checks to allow only some unfree packages
   # Example:
   # {pkgs, ...}:
   # {
@@ -218,7 +218,7 @@ let
 
       however ${getName attrs} only has the outputs: ${builtins.concatStringsSep ", " actualOutputs}
 
-      and is missing the following ouputs:
+      and is missing the following outputs:
 
       ${lib.concatStrings (builtins.map (output: "  - ${output}\n") missingOutputs)}
     '';

--- a/test/diff/idioms_lib_5/out-pure.nix
+++ b/test/diff/idioms_lib_5/out-pure.nix
@@ -78,7 +78,7 @@ let
 
   isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or [ ]) != [ ];
 
-  # Alow granular checks to allow only some unfree packages
+  # Allow granular checks to allow only some unfree packages
   # Example:
   # {pkgs, ...}:
   # {
@@ -254,7 +254,7 @@ let
 
       however ${getName attrs} only has the outputs: ${builtins.concatStringsSep ", " actualOutputs}
 
-      and is missing the following ouputs:
+      and is missing the following outputs:
 
       ${lib.concatStrings (builtins.map (output: "  - ${output}\n") missingOutputs)}
     '';

--- a/test/diff/idioms_lib_5/out.nix
+++ b/test/diff/idioms_lib_5/out.nix
@@ -78,7 +78,7 @@ let
 
   isMarkedInsecure = attrs: (attrs.meta.knownVulnerabilities or [ ]) != [ ];
 
-  # Alow granular checks to allow only some unfree packages
+  # Allow granular checks to allow only some unfree packages
   # Example:
   # {pkgs, ...}:
   # {
@@ -254,7 +254,7 @@ let
 
       however ${getName attrs} only has the outputs: ${builtins.concatStringsSep ", " actualOutputs}
 
-      and is missing the following ouputs:
+      and is missing the following outputs:
 
       ${lib.concatStrings (builtins.map (output: "  - ${output}\n") missingOutputs)}
     '';

--- a/test/diff/idioms_pkgs_5/in.nix
+++ b/test/diff/idioms_pkgs_5/in.nix
@@ -380,7 +380,7 @@ else let
       # Derivations set it to choose what sort of machine could be used to
       # execute the build, The build platform entirely determines this,
       # indeed more finely than Nix knows or cares about. The `system`
-      # attribute of `buildPlatfom` matches Nix's degree of specificity.
+      # attribute of `buildPlatform` matches Nix's degree of specificity.
       # exactly.
       inherit (stdenv.buildPlatform) system;
 

--- a/test/diff/idioms_pkgs_5/out-pure.nix
+++ b/test/diff/idioms_pkgs_5/out-pure.nix
@@ -514,7 +514,7 @@ let
             # Derivations set it to choose what sort of machine could be used to
             # execute the build, The build platform entirely determines this,
             # indeed more finely than Nix knows or cares about. The `system`
-            # attribute of `buildPlatfom` matches Nix's degree of specificity.
+            # attribute of `buildPlatform` matches Nix's degree of specificity.
             # exactly.
             inherit (stdenv.buildPlatform) system;
 

--- a/test/diff/idioms_pkgs_5/out.nix
+++ b/test/diff/idioms_pkgs_5/out.nix
@@ -514,7 +514,7 @@ let
             # Derivations set it to choose what sort of machine could be used to
             # execute the build, The build platform entirely determines this,
             # indeed more finely than Nix knows or cares about. The `system`
-            # attribute of `buildPlatfom` matches Nix's degree of specificity.
+            # attribute of `buildPlatform` matches Nix's degree of specificity.
             # exactly.
             inherit (stdenv.buildPlatform) system;
 

--- a/test/diff/inherit_comment/in.nix
+++ b/test/diff/inherit_comment/in.nix
@@ -12,7 +12,7 @@
     # dontCheck - skip tests
     dontCheck
     # override deps of a package
-    # see what can be overriden - https://github.com/NixOS/nixpkgs/blob/0ba44a03f620806a2558a699dba143e6cf9858db/pkgs/development/haskell-modules/generic-builder.nix#L13
+    # see what can be overridden - https://github.com/NixOS/nixpkgs/blob/0ba44a03f620806a2558a699dba143e6cf9858db/pkgs/development/haskell-modules/generic-builder.nix#L13
     overrideCabal
     ;
 }

--- a/test/diff/inherit_comment/out-pure.nix
+++ b/test/diff/inherit_comment/out-pure.nix
@@ -12,7 +12,7 @@
     # dontCheck - skip tests
     dontCheck
     # override deps of a package
-    # see what can be overriden - https://github.com/NixOS/nixpkgs/blob/0ba44a03f620806a2558a699dba143e6cf9858db/pkgs/development/haskell-modules/generic-builder.nix#L13
+    # see what can be overridden - https://github.com/NixOS/nixpkgs/blob/0ba44a03f620806a2558a699dba143e6cf9858db/pkgs/development/haskell-modules/generic-builder.nix#L13
     overrideCabal
     ;
 }

--- a/test/diff/inherit_comment/out.nix
+++ b/test/diff/inherit_comment/out.nix
@@ -12,7 +12,7 @@
     # dontCheck - skip tests
     dontCheck
     # override deps of a package
-    # see what can be overriden - https://github.com/NixOS/nixpkgs/blob/0ba44a03f620806a2558a699dba143e6cf9858db/pkgs/development/haskell-modules/generic-builder.nix#L13
+    # see what can be overridden - https://github.com/NixOS/nixpkgs/blob/0ba44a03f620806a2558a699dba143e6cf9858db/pkgs/development/haskell-modules/generic-builder.nix#L13
     overrideCabal
     ;
 }

--- a/test/diff/paren/in.nix
+++ b/test/diff/paren/in.nix
@@ -1,6 +1,6 @@
 [
   (done // listToAttrs [ {
-    # multline
+    # multiline
     name = entry;
     value = 1;
   }])

--- a/test/diff/paren/out-pure.nix
+++ b/test/diff/paren/out-pure.nix
@@ -3,7 +3,7 @@
     done
     // listToAttrs [
       {
-        # multline
+        # multiline
         name = entry;
         value = 1;
       }

--- a/test/diff/paren/out.nix
+++ b/test/diff/paren/out.nix
@@ -3,7 +3,7 @@
     done
     // listToAttrs [
       {
-        # multline
+        # multiline
         name = entry;
         value = 1;
       }


### PR DESCRIPTION
## Summary
This PR fixes spelling mistakes in comments, changelog text, and test fixture strings. It does not change formatting behavior or runtime logic.

Closes #379

## Validation
- `nix --extra-experimental-features "nix-command flakes" build .#packages.x86_64-linux.nixfmt`
- `nix --extra-experimental-features "nix-command flakes" build .#checks.x86_64-linux.tests`
- `bash test/test.sh`
