### PR TITLE
feat: Update project, actions, Haskell format, and release more builds to GitHub release to support CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,30 +13,32 @@ permissions:
   pull-requests: write
   contents: read
 
+env:
+  CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        if: github.event_name != 'pull_request_target'
-
-      - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request_target'
+      - uses: actions/checkout@v6
         with:
-          # To prevent running untrusted code from forks,
-          # pull_request_target will cause the base branch to be checked out, not the PR branch.
-          # In our case we check out the PR branch regardless,
-          # because we're sandboxing all untrusted code with a `nix-build`.
-          # (and the sandbox is enabled by default at least on Linux)
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          persist-credentials: false
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
 
-      - uses: cachix/install-nix-action@v26
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: cachix/cachix-action@v14
+      - name: Setup Cachix cache
+        if: env.CACHIX_AUTH_TOKEN != ''
+        uses: cachix/cachix-action@v17
         with:
           name: nixos-nixfmt
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
+      - name: Setup Magic Cache
+        if: env.CACHIX_AUTH_TOKEN == ''
+        uses: DeterminateSystems/magic-nix-cache-action@main
       - name: checks
         run: nix-build -A ci
 
@@ -49,7 +51,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Find Comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -57,7 +59,7 @@ jobs:
           body-includes: Nixpkgs diff
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         id: couc
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -73,14 +75,16 @@ jobs:
       # This is exactly what we want in this case,
       # because the sync-pr.sh script cannot be run sandboxed since it needs to have side effects.
       # Instead, the script itself fetches the PR, but then runs its code within sandboxed derivations.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: cachix/install-nix-action@v26
+      - uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: cachix/cachix-action@v14
+      - uses: cachix/cachix-action@v17
         with:
           name: nixos-nixfmt
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - run: |
           ./scripts/sync-pr.sh \
@@ -89,7 +93,7 @@ jobs:
             https://${{ secrets.MACHINE_USER_PAT }}@github.com/${{ vars.MACHINE_USER }}/nixpkgs
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.couc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,8 @@ jobs:
           if [[ "$IS_PRERELEASE" == "true" ]]; then
             TAG="v${VERSION}-test"
             PRERELEASE_FLAG="--prerelease"
+            # Delete existing pre-release if it exists
+            gh release delete "$TAG" --yes --cleanup-tag 2>/dev/null || true
           else
             TAG="v${VERSION}"
             PRERELEASE_FLAG=""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'nixfmt.cabal'
+  workflow_dispatch:
 
 
 defaults:
@@ -23,6 +24,7 @@ jobs:
       prev_version: ${{ steps.get_version.outputs.prev_version }}
       version: ${{ steps.get_version.outputs.version }}
       version_changed: ${{ steps.get_version.outputs.version_changed }}
+      is_prerelease: ${{ steps.get_version.outputs.is_prerelease }}
 
     steps:
       - name: Checkout main
@@ -41,6 +43,14 @@ jobs:
           echo "Version found in cabal: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Manual dispatch — skipping version comparison"
+            echo "prev_version=0" >> $GITHUB_OUTPUT
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           # Get previous version from last commit
           PREV_VERSION=$(git show HEAD~1:"$CABAL_FILE" | grep -m1 "^version:" | awk '{print $2}')
           echo "Previous version: $PREV_VERSION"
@@ -49,9 +59,11 @@ jobs:
 
           if [ "$PREV_VERSION" != "$VERSION" ]; then
             echo "version_changed=true" >> $GITHUB_OUTPUT
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
             echo "::notice ::✅ Version changed from $PREV_VERSION to $VERSION"
           else
             echo "version_changed=false" >> $GITHUB_OUTPUT
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
             echo "::notice ::Version did not change"
           fi
 
@@ -109,6 +121,7 @@ jobs:
       contents: write
     env:
       VERSION: ${{ needs.check-if-version-changed.outputs.version }}
+      IS_PRERELEASE: ${{ needs.check-if-version-changed.outputs.is_prerelease }}
     steps:
       - name: Checkout main
         uses: actions/checkout@v6
@@ -124,9 +137,13 @@ jobs:
           ' CHANGELOG.md > RELEASE_NOTES.md
 
           if [ ! -s RELEASE_NOTES.md ]; then
-            echo "::error ::No changelog section found for version $VERSION"
-            echo "(Make sure you have a header like '## $VERSION -- YYYY-MM-DD')"
-            exit 1
+            if [[ "$IS_PRERELEASE" == "true" ]]; then
+              echo "Pre-release test build from \`$(git rev-parse --short HEAD)\`." > RELEASE_NOTES.md
+            else
+              echo "::error ::No changelog section found for version $VERSION"
+              echo "(Make sure you have a header like '## $VERSION -- YYYY-MM-DD')"
+              exit 1
+            fi
           fi
 
       - name: Download build artifacts
@@ -139,7 +156,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            TAG="v${VERSION}-test"
+            PRERELEASE_FLAG="--prerelease"
+          else
+            TAG="v${VERSION}"
+            PRERELEASE_FLAG=""
+          fi
+
           chmod +x artifacts/nixfmt_*
-          gh release create "v$VERSION" artifacts/nixfmt_* \
-            --title "v$VERSION" \
-            --notes-file RELEASE_NOTES.md
+          gh release create "$TAG" artifacts/nixfmt_* \
+            --title "$TAG" \
+            --notes-file RELEASE_NOTES.md \
+            $PRERELEASE_FLAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
           name="nixfmt_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m)"
 
           bin=$(cabal list-bin nixfmt)
+          strip "$bin"
           cp "$bin" "${name}"
 
       - name: Upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,19 +7,29 @@ on:
     paths:
       - 'nixfmt.cabal'
 
+
 defaults:
   run:
     shell: bash
 
 jobs:
-  release-if-version-changed:
+  check-if-version-changed:
+    name: Check if version changed
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
+    outputs:
+      prev_version: ${{ steps.get_version.outputs.prev_version }}
+      version: ${{ steps.get_version.outputs.version }}
+      version_changed: ${{ steps.get_version.outputs.version_changed }}
 
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2  # need previous commit for comparison
+          persist-credentials: false
 
       - name: Get version from nixfmt.cabal
         id: get_version
@@ -29,36 +39,84 @@ jobs:
           # Extract the version
           VERSION=$(grep -m1 "^version:" $CABAL_FILE | awk '{print $2}')
           echo "Version found in cabal: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           # Get previous version from last commit
           PREV_VERSION=$(git show HEAD~1:"$CABAL_FILE" | grep -m1 "^version:" | awk '{print $2}')
           echo "Previous version: $PREV_VERSION"
 
-          # Export for later steps
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "prev_version=$PREV_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Check if version changed
-        id: compare
-        env:
-          PREV_VERSION: ${{ steps.get_version.outputs.prev_version }}
-          VERSION: ${{ steps.get_version.outputs.version }}
-        run: |
           if [ "$PREV_VERSION" != "$VERSION" ]; then
-            echo "version_changed=true" >> $GITHUB_ENV
+            echo "version_changed=true" >> $GITHUB_OUTPUT
             echo "::notice ::✅ Version changed from $PREV_VERSION to $VERSION"
           else
-            echo "version_changed=false" >> $GITHUB_ENV
-            echo "::notice ::Version did not change, skipping release"
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+            echo "::notice ::Version did not change"
           fi
-      - name: Extract changelog section for current version
-        if: ${{ env.version_changed == 'true' }}
-        env:
-          VERSION: ${{ steps.get_version.outputs.version }}
-        run: |
-          echo "Extracting changelog section for version $VERSION"
 
-          # Extract everything after the "## <version>" header until the next "## "
+
+  release-if-version-changed:
+    needs: check-if-version-changed
+    if: needs.check-if-version-changed.outputs.version_changed == 'true'
+    name: Building ${{ needs.check-if-version-changed.outputs.version }} for ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+        - ubuntu-22.04
+        - ubuntu-22.04-arm
+        - macos-15
+        - macos-15-intel
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Haskell
+        uses: haskell-actions/setup@v2.10.4
+        with:
+          ghc-version: "9.10.3"
+
+      - name: Configure and build
+        run: |
+          cabal update
+          cabal configure \
+            --enable-executable-stripping \
+            --enable-optimization=2
+          cabal build exe:nixfmt
+
+          name="nixfmt_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m)"
+
+          bin=$(cabal list-bin nixfmt)
+          cp "$bin" "${name}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: nixfmt_${{ matrix.os }}
+          path: "nixfmt_*"
+
+  Create-GitHub-Release:
+    needs:
+      - release-if-version-changed
+      - check-if-version-changed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.check-if-version-changed.outputs.version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Extract changelog section for current version
+        run: |
           awk -v ver="$VERSION" '
             $0 ~ "^##[[:space:]]+" ver {found=1; next}
             found && /^##[[:space:]]+/ {exit}
@@ -66,37 +124,22 @@ jobs:
           ' CHANGELOG.md > RELEASE_NOTES.md
 
           if [ ! -s RELEASE_NOTES.md ]; then
-            echo "::error ::⚠️ No changelog section found for version $VERSION"
+            echo "::error ::No changelog section found for version $VERSION"
             echo "(Make sure you have a header like '## $VERSION -- YYYY-MM-DD')"
-            echo "- No notes will be attached to the release -"
-            echo "No changelog section found for version $VERSION." > RELEASE_NOTES.md
             exit 1
           fi
 
-          echo "---- Extracted Changelog ----"
-          cat RELEASE_NOTES.md
-          echo "--------------------------"
-
-      - name: Setup Nix
-        if: ${{ env.version_changed == 'true' }}
-        uses: cachix/install-nix-action@v26
-
-      - name: Setup Cachix cache
-        if: ${{ env.version_changed == 'true' }}
-        uses: cachix/cachix-action@v14
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
         with:
-          name: nixos-nixfmt
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Build static binary
-        if: ${{ env.version_changed == 'true' }}
-        run: |
-          nix-build -A packages.nixfmt-static
+          path: artifacts
+          merge-multiple: true
 
       - name: Create GitHub Release
-        if: ${{ env.version_changed == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: "${{ steps.get_version.outputs.version }}"
-        run:
-          gh release create v$VERSION ./result/bin/nixfmt --title "v$VERSION" --notes-file RELEASE_NOTES.md 
+        run: |
+          chmod +x artifacts/nixfmt_*
+          gh release create "v$VERSION" artifacts/nixfmt_* \
+            --title "v$VERSION" \
+            --notes-file RELEASE_NOTES.md

--- a/default.nix
+++ b/default.nix
@@ -11,16 +11,6 @@ let
     haskell = super.haskell // {
       packageOverrides = self: super: { nixfmt = self.callCabal2nix "nixfmt" haskellSource { }; };
     };
-
-    treefmt = super.treefmt.overrideAttrs (old: {
-      patches = [
-        # Makes it work in parallel: https://github.com/numtide/treefmt/pull/282
-        (self.fetchpatch {
-          url = "https://github.com/numtide/treefmt/commit/f596795cd24b50f048cc395866bb90a89d99152d.patch";
-          hash = "sha256-EPn+JAT3aZLSWmpdi9ULZ8o8RvrX+UFp0cQWfBcQgVg=";
-        })
-      ];
-    });
   };
 
   pkgs = import nixpkgs {

--- a/default.nix
+++ b/default.nix
@@ -53,7 +53,11 @@ let
   ];
 
   build = lib.pipe pkgs.haskellPackages.nixfmt haskellBuildPipeline;
-  buildStatic = lib.pipe pkgs.pkgsStatic.haskellPackages.nixfmt haskellBuildPipeline;
+  buildStatic =
+    if pkgs.stdenv.hostPlatform.isLinux then
+      lib.pipe pkgs.pkgsStatic.haskellPackages.nixfmt haskellBuildPipeline
+    else
+      null;
 
   treefmtEval = (import sources.treefmt-nix).evalModule pkgs {
     # Used to find the project root
@@ -109,6 +113,8 @@ build
 // {
   packages = {
     nixfmt = build;
+  }
+  // lib.optionalAttrs (buildStatic != null) {
     nixfmt-static = buildStatic;
   };
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -72,35 +72,35 @@ options =
       addDefaultHint value message =
         message ++ "\n[default: " ++ show value ++ "]"
   in Nixfmt
-      { files = [] &= args &= typ "FILES",
-        width =
-          defaultWidth
-            &= help (addDefaultHint defaultWidth "Maximum width in characters"),
-        indent = defaultIndent &= help (addDefaultHint defaultIndent "Number of spaces to use for indentation"),
-        check = False &= help "Check whether files are formatted without modifying them",
-        mergetool = False &= help "Whether to run in git mergetool mode, see https://github.com/NixOS/nixfmt?tab=readme-ov-file#git-mergetool for more info",
-        quiet = False &= help "Do not report errors",
-        strict = False &= help "Enable a stricter formatting mode that isn't influenced as much by how the input is formatted",
-        verify =
-          False
-            &= help
-              "Apply sanity checks on the output after formatting",
-        ast =
-          False
-            &= help
-              "Pretty print the internal AST, only for debugging",
-        filename =
-          Nothing
-            &= help
-              "The filename to display when the file input is given through stdin.\n\
-              \Useful for tools like editors and autoformatters that wish to use Nixfmt without providing it direct file access, while still providing context to where the file is.",
-        ir =
-          False
-            &= help
-              "Pretty print the internal intermediate representation, only for debugging"
-      }
-      &= summary ("nixfmt " ++ versionFromFile)
-      &= help "Format Nix source code"
+       { files = [] &= args &= typ "FILES",
+         width =
+           defaultWidth
+             &= help (addDefaultHint defaultWidth "Maximum width in characters"),
+         indent = defaultIndent &= help (addDefaultHint defaultIndent "Number of spaces to use for indentation"),
+         check = False &= help "Check whether files are formatted without modifying them",
+         mergetool = False &= help "Whether to run in git mergetool mode, see https://github.com/NixOS/nixfmt?tab=readme-ov-file#git-mergetool for more info",
+         quiet = False &= help "Do not report errors",
+         strict = False &= help "Enable a stricter formatting mode that isn't influenced as much by how the input is formatted",
+         verify =
+           False
+             &= help
+               "Apply sanity checks on the output after formatting",
+         ast =
+           False
+             &= help
+               "Pretty print the internal AST, only for debugging",
+         filename =
+           Nothing
+             &= help
+               "The filename to display when the file input is given through stdin.\n\
+               \Useful for tools like editors and autoformatters that wish to use Nixfmt without providing it direct file access, while still providing context to where the file is.",
+         ir =
+           False
+             &= help
+               "Pretty print the internal intermediate representation, only for debugging"
+       }
+       &= summary ("nixfmt " ++ versionFromFile)
+       &= help "Format Nix source code"
 
 data Target = Target
   { tDoRead :: IO Text,

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -41,8 +41,8 @@ executable nixfmt
     , process
 
     -- for System.IO.Atomic
-    , directory        >= 1.3.3 && < 1.4
-    , filepath         >= 1.4.2 && < 1.5
+    , directory        >= 1.3.3 && < 1.5
+    , filepath         >= 1.4.2 && < 1.6
     , safe-exceptions  >= 0.1.7 && < 0.2
   default-language:    Haskell2010
   ghc-options:
@@ -81,7 +81,7 @@ library
   build-depends:
       base             >= 4.12.0
     , containers
-    , megaparsec       >= 9.0.1 && < 9.6
+    , megaparsec       >= 9.0.1 && < 9.8
     , mtl
     , parser-combinators >= 1.0.3 && < 1.4
     , scientific       >= 0.3.0 && < 0.4.0

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -2,9 +2,9 @@
   "pins": {
     "nixpkgs": {
       "type": "Channel",
-      "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-24.05pre596549.db001797591b/nixexprs.tar.xz",
-      "hash": "0260ylnd8kawcd3i9xkm8j295hf3bs377vjff8pm3v914jzld9v9"
+      "name": "nixos-25.11",
+      "url": "https://releases.nixos.org/nixos/25.11/nixos-25.11.8919.d96b37bbeb98/nixexprs.tar.xz",
+      "hash": "0ixgv3ma5nswayzdv83zlcbsyki091smr0gl37gf8gwngimbbvr5"
     },
     "serokell-nix": {
       "type": "Git",

--- a/src/Nixfmt.hs
+++ b/src/Nixfmt.hs
@@ -67,10 +67,10 @@ formatVerify layout path unformatted = do
       Left $
         let minimized = minimize unformattedParsed' (\e -> parse (layout e) == Right (Whole e []))
         in pleaseReport "Parses differently after formatting."
-            <> "\n\nBefore formatting:\n"
-            <> show minimized
-            <> "\n\nAfter formatting:\n"
-            <> show (fromRight (error "TODO") $ parse (layout minimized))
+             <> "\n\nBefore formatting:\n"
+             <> show minimized
+             <> "\n\nAfter formatting:\n"
+             <> show (fromRight (error "TODO") $ parse (layout minimized))
     else
       if formattedOnce /= formattedTwice
         then
@@ -80,10 +80,10 @@ formatVerify layout path unformatted = do
                     unformattedParsed'
                     (\e -> layout e == layout (fromRight (error "TODO") $ parse $ layout e))
             in pleaseReport "Nixfmt is not idempotent."
-                <> "\n\nAfter one formatting:\n"
-                <> unpack (layout minimized)
-                <> "\n\nAfter two:\n"
-                <> unpack (layout (fromRight (error "TODO") $ parse $ layout minimized))
+                 <> "\n\nAfter one formatting:\n"
+                 <> unpack (layout minimized)
+                 <> "\n\nAfter two:\n"
+                 <> unpack (layout (fromRight (error "TODO") $ parse $ layout minimized))
         else Right formattedOnce
   where
     parse = first errorBundlePretty . Megaparsec.parse Parser.file path

--- a/src/Nixfmt/Lexer.hs
+++ b/src/Nixfmt/Lexer.hs
@@ -149,8 +149,8 @@ languageAnnotation = try $ do
     isValidLanguageIdentifier txt =
       let stripped = strip txt
       in not (Text.null stripped)
-          && Text.length stripped <= 30
-          && Text.all (\c -> isAlphaNum c || elem @[] c ['-', '+', '.', '_']) stripped
+           && Text.length stripped <= 30
+           && Text.all (\c -> isAlphaNum c || elem @[] c ['-', '+', '.', '_']) stripped
 
     -- Parser to peek at the next token to see if it's a string delimiter (" or '')
     isNextStringDelimiter = do
@@ -195,13 +195,13 @@ convertTrivia :: [ParseTrivium] -> Pos -> (Maybe TrailingComment, Trivia)
 convertTrivia pts nextCol =
   let (trailing, leading) = span isTrailing pts
   in case (trailing, leading) of
-      -- Special case: if the trailing comment visually forms a block with the start of the following line,
-      -- then treat it like part of those comments instead of a distinct trailing comment.
-      -- This happens especially often after `{` or `[` tokens, where the comment of the first item
-      -- starts on the same line ase the opening token.
-      ([PTLineComment _ pos], (PTNewlines 1) : (PTLineComment _ pos') : _) | pos == pos' -> (Nothing, convertLeading pts)
-      ([PTLineComment _ pos], [PTNewlines 1]) | pos == nextCol -> (Nothing, convertLeading pts)
-      _ -> (convertTrailing trailing, convertLeading leading)
+       -- Special case: if the trailing comment visually forms a block with the start of the following line,
+       -- then treat it like part of those comments instead of a distinct trailing comment.
+       -- This happens especially often after `{` or `[` tokens, where the comment of the first item
+       -- starts on the same line ase the opening token.
+       ([PTLineComment _ pos], (PTNewlines 1) : (PTLineComment _ pos') : _) | pos == pos' -> (Nothing, convertLeading pts)
+       ([PTLineComment _ pos], [PTNewlines 1]) | pos == nextCol -> (Nothing, convertLeading pts)
+       _ -> (convertTrailing trailing, convertLeading leading)
 
 trivia :: Parser [ParseTrivium]
 trivia = many $ hidden $ languageAnnotation <|> lineComment <|> blockComment <|> newlines

--- a/src/Nixfmt/Parser.hs
+++ b/src/Nixfmt/Parser.hs
@@ -282,8 +282,8 @@ splitLines [] = [[]]
 splitLines (TextPart t : xs) =
   let ts = map (pure . TextPart) $ Text.split (== '\n') t
   in case splitLines xs of
-      (xs' : xss) -> init ts ++ ((last ts ++ xs') : xss)
-      _ -> error "unreachable"
+       (xs' : xss) -> init ts ++ ((last ts ++ xs') : xss)
+       _ -> error "unreachable"
 splitLines (x : xs) =
   case splitLines xs of
     (xs' : xss) -> (x : xs') : xss

--- a/src/Nixfmt/Predoc.hs
+++ b/src/Nixfmt/Predoc.hs
@@ -161,9 +161,11 @@ trailing t = [Text 0 0 Trailing t]
 group :: (HasCallStack) => (Pretty a) => a -> Doc
 group x =
   pure . Group RegularG $
-    if p /= [] && (isSoftSpacing (head p) || isSoftSpacing (last p))
-      then error $ "group should not start or end with whitespace, use `group'` if you are sure; " <> show p
-      else p
+    case p of
+      (first' : _)
+        | isSoftSpacing first' || isSoftSpacing (last p) ->
+            error $ "group should not start or end with whitespace, use `group'` if you are sure; " <> show p
+      _ -> p
   where
     p = pretty x
 
@@ -617,14 +619,14 @@ layoutGreedy tw iw doc = Text.concat $ evalState (go [Group RegularG doc] []) (0
     -- In general groups are never empty as empty groups are removed in `fixup`, however this also
     -- gets called for pre and post of priority groups, which may be empty.
     goGroup [] _ = pure []
-    goGroup grp rest = StateT $ \(cc, ci) ->
+    goGroup grp@(first' : rest') rest = StateT $ \(cc, ci) ->
       if cc == 0
         then
           let -- We know that the last printed character was a line break (cc == 0),
               -- therefore drop any leading whitespace within the group to avoid duplicate newlines
-              grp' = case head grp of
-                Spacing _ -> tail grp
-                Group ann ((Spacing _) : inner) -> Group ann inner : tail grp
+              grp' = case first' of
+                Spacing _ -> rest'
+                Group ann ((Spacing _) : inner) -> Group ann inner : rest'
                 _ -> grp
               (nl, off) = nextIndent grp'
 

--- a/src/Nixfmt/Predoc.hs
+++ b/src/Nixfmt/Predoc.hs
@@ -326,16 +326,16 @@ fixup (a@(Spacing _) : Group ann xs : ys) =
       (pre, rest) = span (\x -> isHardSpacing x || isComment x) $ fixup xs
       (post, body) = second (simplifyGroup ann) $ spanEnd isHardSpacing rest
   in if null body
-      then -- Dissolve empty group
-        fixup $ (a : pre) ++ post ++ ys
-      else fixup (a : pre) ++ [Group ann body] ++ fixup (post ++ ys)
+       then -- Dissolve empty group
+         fixup $ (a : pre) ++ post ++ ys
+       else fixup (a : pre) ++ [Group ann body] ++ fixup (post ++ ys)
 -- Handle group, almost the same thing as above
 fixup (Group ann xs : ys) =
   let (pre, rest) = span (\x -> isHardSpacing x || isComment x) $ fixup xs
       (post, body) = second (simplifyGroup ann) $ spanEnd isHardSpacing rest
   in if null body
-      then fixup $ pre ++ post ++ ys
-      else fixup pre ++ [Group ann body] ++ fixup (post ++ ys)
+       then fixup $ pre ++ post ++ ys
+       else fixup pre ++ [Group ann body] ++ fixup (post ++ ys)
 fixup (x : xs) = x : fixup xs
 
 mergeSpacings :: Spacing -> Spacing -> Spacing
@@ -538,60 +538,60 @@ layoutGreedy tw iw doc = Text.concat $ evalState (go [Group RegularG doc] []) (0
             putNL :: Int -> State St [Text]
             putNL n = put (0, indents) $> [newlines n]
         in case x of
-            -- Special case trailing comments. Because in cases like
-            -- [ # comment
-            --   1
-            -- ]
-            -- the comment will be parsed as associated to the inner element next time, rendering it as
-            -- [
-            --   # comment
-            --   1
-            -- ]
-            -- This breaks idempotency. To work around this, we simply shift the comment by one:
-            -- [  # comment
-            --   1
-            -- ]
-            Text _ _ TrailingComment t | cc == 2 && fst (nextIndent xs) > lineNL -> putText' [" ", t]
-              where
-                lineNL = snd $ NonEmpty.head indents
-            Text nl off _ t -> putText nl off t
-            -- This code treats whitespace as "expanded"
-            -- A new line resets the column counter and sets the target indentation as current indentation
-            Spacing sp
-              -- We know that the last printed character was a line break (cc == 0),
-              -- therefore drop any leading whitespace within the group to avoid duplicate newlines
-              | needsIndent -> pure []
-              | otherwise -> case sp of
-                  Break -> putNL 1
-                  Space -> putNL 1
-                  Hardspace -> putText' [" "]
-                  Hardline -> putNL 1
-                  Emptyline -> putNL 2
-                  (Newlines n) -> putNL n
-                  Softbreak
-                    | firstLineFits (tw - cc) tw xs ->
-                        pure []
-                    | otherwise -> putNL 1
-                  Softspace
-                    | firstLineFits (tw - cc - 1) tw xs ->
-                        putText' [" "]
-                    | otherwise -> putNL 1
-            Group ann ys ->
-              let -- fromMaybe lifted to (StateT s Maybe)
-                  fromMaybeState :: State s a -> StateT s Maybe a -> State s a
-                  fromMaybeState l r = state $ \s -> fromMaybe (runState l s) (runStateT r s)
-              in -- Try to fit the entire group first
-                 goGroup ys xs
-                  -- If that fails, check whether the group contains any priority groups within its children and try to expand them first
-                  -- Ignore transparent groups as their priority children have already been handled up in the parent (and failed)
-                  <|> ( if ann /= Transparent
-                          then -- Each priority group will be handled individually, and the priority groups are tried in reverse order
-                            asum $ map (`goPriorityGroup` xs) $ reverse $ priorityGroups ys
-                          else empty
-                      )
-                  -- Otherwise, dissolve the group by mapping its members to the target indentation
-                  -- This also implies that whitespace in there will now be rendered "expanded".
-                  & fromMaybeState (go ys xs)
+             -- Special case trailing comments. Because in cases like
+             -- [ # comment
+             --   1
+             -- ]
+             -- the comment will be parsed as associated to the inner element next time, rendering it as
+             -- [
+             --   # comment
+             --   1
+             -- ]
+             -- This breaks idempotency. To work around this, we simply shift the comment by one:
+             -- [  # comment
+             --   1
+             -- ]
+             Text _ _ TrailingComment t | cc == 2 && fst (nextIndent xs) > lineNL -> putText' [" ", t]
+               where
+                 lineNL = snd $ NonEmpty.head indents
+             Text nl off _ t -> putText nl off t
+             -- This code treats whitespace as "expanded"
+             -- A new line resets the column counter and sets the target indentation as current indentation
+             Spacing sp
+               -- We know that the last printed character was a line break (cc == 0),
+               -- therefore drop any leading whitespace within the group to avoid duplicate newlines
+               | needsIndent -> pure []
+               | otherwise -> case sp of
+                   Break -> putNL 1
+                   Space -> putNL 1
+                   Hardspace -> putText' [" "]
+                   Hardline -> putNL 1
+                   Emptyline -> putNL 2
+                   (Newlines n) -> putNL n
+                   Softbreak
+                     | firstLineFits (tw - cc) tw xs ->
+                         pure []
+                     | otherwise -> putNL 1
+                   Softspace
+                     | firstLineFits (tw - cc - 1) tw xs ->
+                         putText' [" "]
+                     | otherwise -> putNL 1
+             Group ann ys ->
+               let -- fromMaybe lifted to (StateT s Maybe)
+                   fromMaybeState :: State s a -> StateT s Maybe a -> State s a
+                   fromMaybeState l r = state $ \s -> fromMaybe (runState l s) (runStateT r s)
+               in -- Try to fit the entire group first
+                  goGroup ys xs
+                    -- If that fails, check whether the group contains any priority groups within its children and try to expand them first
+                    -- Ignore transparent groups as their priority children have already been handled up in the parent (and failed)
+                    <|> ( if ann /= Transparent
+                            then -- Each priority group will be handled individually, and the priority groups are tried in reverse order
+                              asum $ map (`goPriorityGroup` xs) $ reverse $ priorityGroups ys
+                            else empty
+                        )
+                    -- Otherwise, dissolve the group by mapping its members to the target indentation
+                    -- This also implies that whitespace in there will now be rendered "expanded".
+                    & fromMaybeState (go ys xs)
 
     goPriorityGroup :: (Doc, Doc, Doc) -> Doc -> StateT St Maybe [Text]
     goPriorityGroup (pre, prio, post) rest = do
@@ -633,10 +633,10 @@ layoutGreedy tw iw doc = Text.concat $ evalState (go [Group RegularG doc] []) (0
                   lastLineNL = snd $ NonEmpty.head ci
                   lineNL = lastLineNL + (if nl > lastLineNL then iw else 0)
           in fits indentWillIncrease (tw - firstLineWidth rest) grp'
-              <&> \t -> runState (putText nl off t) (cc, ci)
+               <&> \t -> runState (putText nl off t) (cc, ci)
         else
           let indentWillIncrease = if fst (nextIndent rest) > lineNL then iw else 0
                 where
                   lineNL = snd $ NonEmpty.head ci
           in fits (indentWillIncrease - cc) (tw - cc - firstLineWidth rest) grp
-              <&> \t -> ([t], (cc + textWidth t, ci))
+               <&> \t -> ([t], (cc + textWidth t, ci))

--- a/src/Nixfmt/Pretty.hs
+++ b/src/Nixfmt/Pretty.hs
@@ -219,9 +219,9 @@ prettySet _ (krec, paropen@(LoneAnn _), Items [], parclose@Ann{preTrivia = []}) 
 prettySet wide (krec, paropen@Ann{trailComment = post}, binders, parclose) =
   let !surrounded = surroundWith sep (nest $ pretty post <> renderItems hardline binders)
   in pretty (fmap (,hardspace) krec)
-      <> pretty (paropen{trailComment = Nothing})
-      <> surrounded
-      <> pretty parclose
+       <> pretty (paropen{trailComment = Nothing})
+       <> surrounded
+       <> pretty parclose
   where
     sep =
       if wide && not (null (unItems binders))
@@ -506,29 +506,29 @@ prettyApp indentFunction pre hasPost f a =
         let renderedF = pre <> group' Transparent toRender
             renderedFUnexpanded = unexpandSpacing' Nothing renderedF
         in if isSimple (Application f a) && isJust renderedFUnexpanded
-            then renderIfSimple (fromJust renderedFUnexpanded)
-            else renderOtherwise renderedF
+             then renderIfSimple (fromJust renderedFUnexpanded)
+             else renderOtherwise renderedF
 
       post = if hasPost then line' else mempty
   in pretty comment'
-      <> case (fWithoutComment, a) of
-        -- When the two last arguments are lists, render these specially (same as above)
-        -- Also no need to wrap in renderSimple here, because we know that these kinds of arguments
-        -- are never "simple" by definition.
-        (Application fWithoutCommandAndWithoutArg l1@(Term List{}), l2@(Term List{})) ->
-          group' RegularG $
-            (pre <> group' Transparent (absorbApp fWithoutCommandAndWithoutArg))
-              <> line
-              <> nest (group (absorbInner l1))
-              <> line
-              <> nest (group (absorbInner l2))
-              <> post
-        _ ->
-          renderSimple
-            (absorbApp fWithoutComment)
-            (\fRendered -> group' RegularG $ fRendered <> hardspace <> absorbLast a)
-            (\fRendered -> group' RegularG $ fRendered <> line <> absorbLast a <> post)
-      <> (if hasPost && not (null comment') then hardline else mempty)
+       <> case (fWithoutComment, a) of
+         -- When the two last arguments are lists, render these specially (same as above)
+         -- Also no need to wrap in renderSimple here, because we know that these kinds of arguments
+         -- are never "simple" by definition.
+         (Application fWithoutCommandAndWithoutArg l1@(Term List{}), l2@(Term List{})) ->
+           group' RegularG $
+             (pre <> group' Transparent (absorbApp fWithoutCommandAndWithoutArg))
+               <> line
+               <> nest (group (absorbInner l1))
+               <> line
+               <> nest (group (absorbInner l2))
+               <> post
+         _ ->
+           renderSimple
+             (absorbApp fWithoutComment)
+             (\fRendered -> group' RegularG $ fRendered <> hardspace <> absorbLast a)
+             (\fRendered -> group' RegularG $ fRendered <> line <> absorbLast a <> post)
+       <> (if hasPost && not (null comment') then hardline else mempty)
 
 prettyOp :: Bool -> Expression -> Leaf -> Doc
 prettyOp forceFirstTermWide operation op =
@@ -560,7 +560,7 @@ prettyOp forceFirstTermWide operation op =
       prettyOperation (Just op', expr) =
         sep <> pretty (moveTrailingCommentUp op') <> nest (absorbOperation expr)
   in group' RegularG $
-      (concatMap prettyOperation . flatten Nothing) operation
+       (concatMap prettyOperation . flatten Nothing) operation
   where
     isPipe (Ann{value = TPipeForward}) = True
     isPipe (Ann{value = TPipeBackward}) = True

--- a/src/Nixfmt/Types.hs
+++ b/src/Nixfmt/Types.hs
@@ -372,7 +372,7 @@ instance LanguageElement Term where
 
   walkSubprograms = \case
     -- Map each item to a singleton list, then handle that
-    (List _ items _) | Prelude.length (unItems items) == 1 -> case Prelude.head (unItems items) of
+    (List _ items _) | [single] <- unItems items -> case single of
       (Item item) -> [Term item]
       (Comments _) -> []
     (List open items close) ->
@@ -381,7 +381,7 @@ instance LanguageElement Term where
           [Term (List (stripTrivia open) (Items [Item item]) (stripTrivia close))]
         Comments c ->
           [Term (List (stripTrivia open) (Items [Comments c]) (stripTrivia close))]
-    (Set _ _ items _) | Prelude.length (unItems items) == 1 -> case Prelude.head (unItems items) of
+    (Set _ _ items _) | [single] <- unItems items -> case single of
       (Item (Inherit _ from sels _)) ->
         (Term <$> maybeToList from) ++ concatMap walkSubprograms sels
       (Item (Assignment sels _ expr _)) ->

--- a/test/test.sh
+++ b/test/test.sh
@@ -35,7 +35,7 @@ verifyCorrect() {
   shift
 
   echo "Checking $file (${*:-no options}) …"
-  if ! out=$(nixfmt --strict --verify "$@" < "$file"); then
+  if ! out=$(nixfmt --strict --verify "$@" - < "$file"); then
     echo "[ERROR] failed nixfmt verification"
     exit 1
   fi
@@ -60,7 +60,7 @@ verifyCorrect test/correct-indent-4.nix --indent=4
 
 # Verify "invalid"
 for file in test/invalid/*.nix; do
-  if nixfmt < "$file" > /dev/null 2>&1; then
+  if nixfmt - < "$file" > /dev/null 2>&1; then
     echo "[ERROR] $file should have failed nixfmt"
     exit 1
   else
@@ -71,7 +71,7 @@ done
 # Verify "diff"
 for file in test/diff/**/in.nix; do
   echo "Checking $file …"
-  out="$(nixfmt --verify < "$file")"
+  out="$(nixfmt --verify - < "$file")"
   outfile="$(dirname "$file")/out.nix"
 
   if diff --color=always --unified "$outfile" <(echo "$out"); then
@@ -85,7 +85,7 @@ for file in test/diff/**/in.nix; do
   fi
 
   echo "Checking $file with --strict …"
-  out="$(nixfmt --strict --verify < "$file")"
+  out="$(nixfmt --strict --verify - < "$file")"
   outfile="$(dirname "$file")/out-pure.nix"
 
   if diff --color=always --unified "$outfile" <(echo "$out"); then


### PR DESCRIPTION
This PR is structured into a series of logically scoped commits to enable the GitHub release workflow to produce additional build artifacts. The goal is to allow tools such as `mise-en-place` and `hk` to install `nixfmt` without requiring a full Nix environment, particularly in constrained environments like GitHub Actions runners.

A significant portion of the work focused on producing static builds for both `x86_64` and `arm64`. This led to updates to `nixpkgs` and the removal of the `treefmt` patch. Despite these efforts, GHC does not appear to reliably support static builds on `arm64`. Given the limits of my Haskell experience, I stopped further investigation at that point.

As a pragmatic alternative, this PR expands support across modern Linux and Darwin systems rather than pursuing full static portability.

The release workflow has been refactored to improve clarity and efficiency:
* Version detection now runs as a separate job. If no new version is found, the workflow exits early. This eliminates the need for conditional logic in individual steps.
* Builds are executed via a matrix across supported operating systems and architectures, avoiding redundant checks per environment.
* The release process is isolated into its own job. A release is only created if all builds succeed, and all generated artifacts are attached at creation time.
* Additional, the release workflow can be triggered manually using a `workflow_dispatch` which will use the latest version number and build a pre-release with the tag being the `${version}-test`, i.e. `v1.2.0-test`

Release artifacts are named by operating system and architecture. This enables tools like `mise` to resolve and install the correct binary automatically (e.g., `mise use github:NixOS/nixfmt`).

Validation was performed on **Ubuntu Jammy** and **Noble**, and **macOS 15** and **26**, across both **arm64** and **x86_64**. All unit tests pass, and local builds succeed using `nix develop` followed by `cabal build`.

Given the scope of changes, commits have been kept intentionally granular so that individual changes can be reviewed, modified, or dropped as needed.