### PR TITLE
Enforce that there are no warnings in our haskell code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ You can also reach us on Matrix at `#nix-formatting:nixos.org`.
 
 Enter a development shell with `nix-shell`, `nix develop` or automatically with [direnv](https://direnv.net/), after which you can:
 - Build (& run): `cabal build` (`cabal run`)
-- Build with fatal warnings (as in CI): `cabal build --flag werror`. May require `cabal clean` beforehand.
+- Build and ignore warnings: `cabal build --flag -werror`. This is useful when
+  hacking locally, but code must be free of warnings before merging.
 - Debug: `cabal repl`
 - Format the codebase: `treefmt`
 - [Set up](https://haskell-language-server.readthedocs.io/en/latest/configuration.html#configuring-your-editor) your LSP-editor to use `haskell-language-server`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ You can also reach us on Matrix at `#nix-formatting:nixos.org`.
 
 Enter a development shell with `nix-shell`, `nix develop` or automatically with [direnv](https://direnv.net/), after which you can:
 - Build (& run): `cabal build` (`cabal run`)
+- Build with fatal warnings (as in CI): `cabal build --flag werror`. May require `cabal clean` beforehand.
 - Debug: `cabal repl`
 - Format the codebase: `treefmt`
 - [Set up](https://haskell-language-server.readthedocs.io/en/latest/configuration.html#configuring-your-editor) your LSP-editor to use `haskell-language-server`

--- a/default.nix
+++ b/default.nix
@@ -59,6 +59,7 @@ let
   haskellBuildPipeline = [
     haskell.lib.justStaticExecutables
     haskell.lib.dontHaddock
+    (haskell.lib.compose.enableCabalFlag "werror")
     (drv: lib.lazyDerivation { derivation = drv; })
   ];
 

--- a/default.nix
+++ b/default.nix
@@ -59,7 +59,6 @@ let
   haskellBuildPipeline = [
     haskell.lib.justStaticExecutables
     haskell.lib.dontHaddock
-    (haskell.lib.compose.enableCabalFlag "werror")
     (drv: lib.lazyDerivation { derivation = drv; })
   ];
 

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -19,6 +19,11 @@ source-repository head
   type:     git
   location: git://github.com/NixOS/nixfmt.git
 
+flag werror
+  description: Treat warnings as errors
+  default: False
+  manual: True
+
 common warnings
   ghc-options:
     -Wall
@@ -27,6 +32,10 @@ common warnings
     -Wincomplete-uni-patterns
     -Wredundant-constraints
     -Wno-orphans
+
+  if flag(werror)
+    ghc-options:
+      -Werror
 
 executable nixfmt
   import: warnings

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.0
+cabal-version:       3.8
 name:                nixfmt
 version:             1.2.0
 synopsis:            Official formatter for Nix code
@@ -19,7 +19,18 @@ source-repository head
   type:     git
   location: git://github.com/NixOS/nixfmt.git
 
+common warnings
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wno-orphans
+
 executable nixfmt
+  import: warnings
+
   main-is:             Main.hs
   other-modules:
     Paths_nixfmt
@@ -46,14 +57,11 @@ executable nixfmt
     , safe-exceptions  >= 0.1.7 && < 0.2
   default-language:    Haskell2010
   ghc-options:
-    -Wall
-    -Wcompat
-    -Wincomplete-record-updates
-    -Wincomplete-uni-patterns
-    -Wredundant-constraints
     -threaded
 
 library
+  import: warnings
+
   exposed-modules:
     Nixfmt
     Nixfmt.Lexer
@@ -89,10 +97,3 @@ library
     , transformers
     , pretty-simple
   default-language:    Haskell2010
-  ghc-options:
-    -Wall
-    -Wcompat
-    -Wincomplete-record-updates
-    -Wincomplete-uni-patterns
-    -Wredundant-constraints
-    -Wno-orphans

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -21,7 +21,7 @@ source-repository head
 
 flag werror
   description: Treat warnings as errors
-  default: False
+  default: True
   manual: True
 
 common warnings


### PR DESCRIPTION
(There are multiple commits in here, I suggest reading them separately)

We had a bunch of warnings enabled, but the build would still succeed if
any of them fired. Now we have a project wide `werror` flag which
determines whether or not these warnings are fatal (IIUC, this is best
practice in the haskell ecosystem, as others may want to build your
project with a different version of ghc, which may emit different
warnings.
