### PR TITLE
ci: Do not persist checkout credentials

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
+        with:
+          persist-credentials: false
 
       - uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
@@ -29,6 +31,7 @@ jobs:
           # because we're sandboxing all untrusted code with a `nix-build`.
           # (and the sandbox is enabled by default at least on Linux)
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          persist-credentials: false
 
       - uses: cachix/install-nix-action@v26
 
@@ -74,6 +77,8 @@ jobs:
       # because the sync-pr.sh script cannot be run sandboxed since it needs to have side effects.
       # Instead, the script itself fetches the PR, but then runs its code within sandboxed derivations.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: cachix/install-nix-action@v26
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2  # need previous commit for comparison
+          persist-credentials: false
 
       - name: Get version from nixfmt.cabal
         id: get_version


### PR DESCRIPTION
These credentials are never re-used so there is no good reason for keeping them.

Note: More recent versions of actions/checkout improved a bit the behavior, see https://github.com/orgs/community/discussions/179107