### PR TITLE
Use `--raw` instead of `tr`

### DIFF
--- a/scripts/sync-pr.sh
+++ b/scripts/sync-pr.sh
@@ -221,7 +221,7 @@ git -C nixpkgs checkout base
 # Since they never change, it would be wasteful to import them multiple times for each nixfmt run.
 # So instead we just import them once and reuse that result throughout
 step "Importing Nix files from base commit into the Nix store"
-baseStorePath=$(nix-instantiate --eval --read-write-mode "$SCRIPT_DIR/sync-pr-support.nix" -A repoNixFiles.outPath --arg repo "$PWD/nixpkgs" | tr -d '"')
+baseStorePath=$(nix-instantiate --eval --read-write-mode --raw "$SCRIPT_DIR/sync-pr-support.nix" -A repoNixFiles.outPath --arg repo "$PWD/nixpkgs")
 echo "$baseStorePath"
 
 step "Fetching contents of the starting commit and updating the mirror branch"


### PR DESCRIPTION
`nix-instantiate` got a `--raw` flag that landed in nix v2.26.0, which was released Jan 2025:
<https://github.com/nixos/nix/commit/7a8a28629c61c75af010ff0a5a88c16c4ce536c7>.