### PR TITLE
Remove confusing use of `with`

### DIFF
--- a/scripts/sync-pr-support.nix
+++ b/scripts/sync-pr-support.nix
@@ -28,8 +28,8 @@ in
     in
     pkgs.runCommand "formatted"
       {
-        nativeBuildInputs = with pkgs; [
-          treefmt
+        nativeBuildInputs = [
+          pkgs.treefmt
           nixfmt
         ];
         treefmtConfig = ''


### PR DESCRIPTION
`nixfmt` is in `pkgs`, but we're not trying to use that one. The previous code worked, due to the sometimes surprising way that `with` works, but I think this alternate way of writing it is much clearer.