### PR TITLE
workflows/main: re-enable read-only cachix for untrusted builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,10 +36,10 @@ jobs:
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-        if: github.event_name != 'pull_request_target'
         with:
           name: nixos-nixfmt
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: ${{ github.event_name == 'push' && secrets.CACHIX_AUTH_TOKEN || '' }}
+          skipPush: ${{ github.event_name != 'push' }}
 
       - name: checks
         run: nix-build -A ci
@@ -85,6 +85,12 @@ jobs:
           persist-credentials: false
 
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
+
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: nixos-nixfmt
+          authToken: ${{ github.event_name == 'push' && secrets.CACHIX_AUTH_TOKEN || '' }}
+          skipPush: ${{ github.event_name != 'push' }}
 
       - run: |
           ./scripts/sync-pr.sh \


### PR DESCRIPTION
This partially reverts 903898a5e850e4b6d4453b93b51caec19370e39f from #393.

Cachix is configured on all runs, but the `authToken` is only configured on `push` events to avoid exposing it to untrusted PR code.

cc @mdaniels5757 