### PR TITLE
flake: drop flake-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,29 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils"
+        "systems": "systems"
       }
     },
     "systems": {
+      "flake": false,
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -1,29 +1,44 @@
 {
-
-  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.systems = {
+    type = "github";
+    owner = "nix-systems";
+    repo = "default";
+    flake = false;
+  };
 
   outputs =
-    { flake-utils, self }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        result = import ./default.nix { inherit system; };
-      in
-      {
-        packages = result.packages // {
-          default = result;
-        };
+    inputs:
+    let
+      systems = import inputs.systems;
 
-        apps.default = {
-          type = "app";
-          program = "${result}/bin/nixfmt";
-        };
+      genAttrs =
+        names: fn:
+        builtins.listToAttrs (
+          map (name: {
+            inherit name;
+            value = fn name;
+          }) names
+        );
 
-        checks = result.checks;
+      perSystem = genAttrs systems;
 
-        devShells.default = result.shell;
+      results = perSystem (system: import ./. { inherit system; });
+      mapResults = fn: builtins.mapAttrs (_: fn) results;
+    in
+    {
+      packages = mapResults (result: result.packages // { default = result; });
 
-        formatter = result.treefmt;
-      }
-    );
+      apps = mapResults (result: {
+        default.type = "app";
+        default.program = "${result}/bin/nixfmt";
+      });
+
+      checks = mapResults (result: result.checks);
+
+      devShells = mapResults (result: {
+        default = result.shell;
+      });
+
+      formatter = mapResults (result: result.treefmt);
+    };
 }


### PR DESCRIPTION
I noticed we were using flake-utils, which is a bit of an overkill dependency for our minimal flake setup.

- Drop flake-utils
- Depend on nix-systems directly (instead of transitively).
- Implement a minimal `mapAttrs`-based "for each system"
- Re-implement `genAttrs`, instead of instantiating an extra `nixpkgs/lib` instance
