### PR TITLE
don't derive Typeable

### DIFF
--- a/main.nix
+++ b/main.nix
@@ -73,7 +73,7 @@ let
   };
 
   checks = {
-    inherit build;
+    inherit build buildStatic;
     cabal-check = pkgs.stdenvNoCC.mkDerivation {
       name = "nixfmt-cabal-check";
       src = source;

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -25,7 +25,6 @@ import Nixfmt.Predoc (layout)
 import Paths_nixfmt (version)
 import System.Console.CmdArgs (
   Data,
-  Typeable,
   args,
   cmdArgs,
   help,
@@ -60,7 +59,7 @@ data Nixfmt = Nixfmt
     filename :: Maybe FilePath,
     ir :: Bool
   }
-  deriving (Show, Data, Typeable)
+  deriving (Show, Data)
 
 versionFromFile :: String
 versionFromFile = maybe (showVersion version) unpack $(embedFileIfExists ".version")


### PR DESCRIPTION
fixes nixfmt-static: https://github.com/NixOS/nixfmt/actions/runs/26479709024/job/77973918363

not sure why the static build behaves differently here, maybe it would be worth testing it in ci?