### PR TITLE
fix darwin build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,18 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    name: check ${{ matrix.system }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - system: aarch64-darwin
+            runner: macos-latest
+          - system: aarch64-linux
+            runner: ubuntu-24.04-arm
+          - system: x86_64-linux
+            runner: ubuntu-latest
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: github.event_name != 'pull_request_target'
@@ -42,7 +53,7 @@ jobs:
           skipPush: ${{ github.event_name != 'push' }}
 
       - name: checks
-        run: nix-build -A ci
+        run: nix-build -A ci --argstr system "${{ matrix.system }}"
 
   nixpkgs-diff:
     runs-on: ubuntu-latest

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -38,6 +38,12 @@ common warnings
     ghc-options:
       -Werror
 
+  -- the executable name nixfmt and the library namespace Nixfmt can collide on
+  -- darwin due to case insentivity on APFS
+  if os(darwin)
+    ghc-options:
+      -optP-Wno-nonportable-include-path
+
 executable nixfmt
   import: warnings
 


### PR DESCRIPTION
also enables ci (only the `nix-build -A ci` part) on darwin, we can test aarch64-linux too but it might be out of scope for this pr

https://github.com/haskell/cabal/issues/4739#issuecomment-359209133