### PR TITLE
ci: skip static build on darwin 

### DIFF
--- a/main.nix
+++ b/main.nix
@@ -138,6 +138,12 @@ let
     };
     treefmt = treefmtEval.config.build.check source;
   };
+
+  skippedChecks = lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+    # static pretty-simple fails to build on darwin
+    # https://github.com/NixOS/nixfmt/issues/411
+    "buildStatic"
+  ];
 in
 {
   packages = {
@@ -162,7 +168,7 @@ in
 
   inherit checks;
 
-  ci = pkgs.linkFarm "ci" checks;
+  ci = pkgs.linkFarm "ci" (removeAttrs checks skippedChecks);
 
   treefmt = treefmtEval.config.build.wrapper;
 }


### PR DESCRIPTION
static pretty-simple (dependency) fails to build on darwin: https://github.com/NixOS/nixfmt/actions/runs/26721856555/job/78750249867#step:6:47658

i can't think of a trivial fix, disabling it for now so 1.3.1 can be released