### PR TITLE
Release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for nixfmt
 
+## 1.3.1 -- 2026-05-31
+- Fixed aarch64-darwin build: <https://github.com/NixOS/nixfmt/pull/409>
+- Added aarch64-linux and aarch64-darwin builds to CI: <https://github.com/NixOS/nixfmt/pull/409>
+
 ## 1.3.0 -- 2026-05-26
 - Updated our dependencies: <https://github.com/NixOS/nixfmt/pull/389>
 - Replaced references to `nixfmt-rfc-style` with `nixfmt`: <https://github.com/NixOS/nixfmt/pull/369>, <https://github.com/NixOS/nixfmt/pull/389>

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.8
 name:                nixfmt
-version:             1.3.0
+version:             1.3.1
 synopsis:            Official formatter for Nix code
 description:
   Nixfmt is the official formatter for Nix language code.


### PR DESCRIPTION
https://github.com/NixOS/nixfmt/compare/v1.3.0...0f73d1b35f48ad0d42112a51de1b5a483e2aef98

- Fixed aarch64-darwin build: <https://github.com/NixOS/nixfmt/pull/409>
- Added aarch64-linux and aarch64-darwin builds to CI: <https://github.com/NixOS/nixfmt/pull/409>

