### PR TITLE
fix(sync-pr): build each Nixfmt revision via pure flakes

### DIFF
--- a/scripts/sync-pr-support.nix
+++ b/scripts/sync-pr-support.nix
@@ -22,27 +22,24 @@ in
   # but with all Nix files formatted with the given nixfmt
   formattedGitRepo =
     { storePath, nixfmtPath }:
-    let
-      nixfmt = (import nixfmtPath { }).packages.nixfmt;
-    in
     pkgs.runCommand "formatted"
       {
         nativeBuildInputs = [
           pkgs.treefmt
-          nixfmt
         ];
-        treefmtConfig = ''
-          [formatter.nixfmt]
-          command = "nixfmt"
-          options = [ "--verify" ]
-          includes = [ "*.nix" ]
-        '';
-        passAsFile = [ "treefmtConfig" ];
+
+        treefmtConfig = pkgs.writers.writeTOML "treefmt.toml" {
+          formatter.nixfmt = {
+            command = builtins.storePath nixfmtPath;
+            options = [ "--verify" ];
+            includes = [ "*.nix" ];
+          };
+        };
       }
       ''
         cp -r --no-preserve=mode ${builtins.storePath storePath} $out
         treefmt \
-          --config-file "$treefmtConfigPath" \
+          --config-file "$treefmtConfig" \
           --tree-root "$out" \
           --no-cache
       '';

--- a/scripts/sync-pr.sh
+++ b/scripts/sync-pr.sh
@@ -263,6 +263,11 @@ next() {
 
   update "$index"
 
+  # Build this PR commit's nixfmt package
+  step "Build Nixfmt for commit $index (${prCommits[$index]})"
+  nix --extra-experimental-features "nix-command flakes" build "$PWD/nixfmt"
+  exe=$(realpath result/bin/nixfmt)
+
   step "Checking out Nixpkgs at the base commit"
   git -C nixpkgs checkout base -- .
 
@@ -270,7 +275,7 @@ next() {
 
   # This uses always the same sync-pr-support.nix file from the same nixfmt branch that this script is in,
   # but doesn't use anything else from that nixfmt branch. Instead the nixfmtPath is used for the formatting.
-  if ! nix-build "$SCRIPT_DIR/sync-pr-support.nix" -A formattedGitRepo --arg storePath "$baseStorePath" --arg nixfmtPath "$PWD/nixfmt"; then
+  if ! nix-build "$SCRIPT_DIR/sync-pr-support.nix" -A formattedGitRepo --arg storePath "$baseStorePath" --arg nixfmtPath "$exe"; then
     echo -e "\e[31mFailed to run nixfmt on some files\e[0m"
     exit 1
   fi


### PR DESCRIPTION
Me and @jfly worked on this together over jitsi.

We can gain some purity guarantees by building the PR's Nixfmt revisions using a flakes-based workflow. Tried to keep other changes to a minimum.

We did some smoke testing on my fork, at https://github.com/MattSturgeon/nixfmt/pull/1
Not thoroughly tested, but hopefully the changes are straightforward enough.
