### PR TITLE
fix: keep language annotations attached when hoisting application comments

### DIFF
--- a/src/Nixfmt/Pretty.hs
+++ b/src/Nixfmt/Pretty.hs
@@ -90,6 +90,10 @@ moveTrailingCommentUp a = a
 prependTrivia :: Trivia -> Ann a -> Ann a
 prependTrivia extra a@Ann{preTrivia} = a{preTrivia = extra <> preTrivia}
 
+isLangAnnotation :: Trivium -> Bool
+isLangAnnotation (LanguageAnnotation _) = True
+isLangAnnotation _ = False
+
 -- | Get the source line of the first token in a language element
 firstTokenLine :: (LanguageElement a) => a -> Pos
 firstTokenLine = snd . mapFirstToken' (\a -> (a, sourceLine a))
@@ -509,11 +513,16 @@ prettyApp indentFunction pre hasPost f a =
         absorbParen open expr close
       absorbLast arg = group' RegularG $ nest $ pretty arg
 
-      -- Extract comment before the first function and move it out, to prevent functions being force-expanded
+      -- Extract comment before the first function and move it out, to prevent functions being force-expanded.
+      -- Language annotations must stay attached to their token.
       (fWithoutComment, comment') =
         mapFirstToken'
-          ((\a'@Ann{preTrivia} -> (a'{preTrivia = []}, preTrivia)) . moveTrailingCommentUp)
+          (hoistNonAnnotationTrivia . moveTrailingCommentUp)
           f
+        where
+          hoistNonAnnotationTrivia a'@Ann{preTrivia} =
+            let (annots, hoisted) = Seq.partition isLangAnnotation preTrivia
+            in (a'{preTrivia = annots}, hoisted)
 
       -- renderSimple will take a document to render, and call one of two callbacks depending on whether
       -- it can take a simplified layout (with removed line breaks) or not.
@@ -665,9 +674,6 @@ isAbsorbable (Set _ paropen items _)
 -- except for language annotations (/* lua */, etc.) which can stay compact.
 isAbsorbable (Parenthesized (LoneAnn _) (Term t) _) =
   matchFirstToken (all isLangAnnotation . preTrivia) t && isAbsorbable t
-  where
-    isLangAnnotation (LanguageAnnotation _) = True
-    isLangAnnotation _ = False
 isAbsorbable _ = False
 
 isAbsorbableTerm :: Term -> Bool

--- a/test/diff/language-annotation/in.nix
+++ b/test/diff/language-annotation/in.nix
@@ -160,4 +160,17 @@
   annotationAfterTrivia = [ # x
     /* sh */ "ls"
   ];
+
+  # Trailing comment between annotated string and application argument;
+  # the hoisted comment must not land between the annotation and its string
+  # (string application is semantically invalid but syntactically legal)
+  trailingCommentApp = /*bash*/''echo lang annotation with trail comment'' # trailing comment
+    A;
+
+  # Same shape with a block comment instead of a line comment
+  trailingBlockCommentApp = /*bash*/''echo hi'' /* trailing comment */  A;
+
+  # Same shape with the annotated string as a middle argument must stay stable
+  trailingCommentArg = runCommand /*bash*/''echo hi'' # trailing comment
+    A;
 }

--- a/test/diff/language-annotation/out-pure.nix
+++ b/test/diff/language-annotation/out-pure.nix
@@ -174,4 +174,21 @@
     # x
     /* sh */ "ls"
   ];
+
+  # Trailing comment between annotated string and application argument;
+  # the hoisted comment must not land between the annotation and its string
+  # (string application is semantically invalid but syntactically legal)
+  trailingCommentApp =
+    # trailing comment
+    /* bash */ "echo lang annotation with trail comment" A;
+
+  # Same shape with a block comment instead of a line comment
+  trailingBlockCommentApp =
+    # trailing comment
+    /* bash */ "echo hi" A;
+
+  # Same shape with the annotated string as a middle argument must stay stable
+  trailingCommentArg =
+    runCommand /* bash */ "echo hi" # trailing comment
+      A;
 }

--- a/test/diff/language-annotation/out.nix
+++ b/test/diff/language-annotation/out.nix
@@ -174,4 +174,21 @@
     # x
     /* sh */ "ls"
   ];
+
+  # Trailing comment between annotated string and application argument;
+  # the hoisted comment must not land between the annotation and its string
+  # (string application is semantically invalid but syntactically legal)
+  trailingCommentApp =
+    # trailing comment
+    /* bash */ "echo lang annotation with trail comment" A;
+
+  # Same shape with a block comment instead of a line comment
+  trailingBlockCommentApp =
+    # trailing comment
+    /* bash */ "echo hi" A;
+
+  # Same shape with the annotated string as a middle argument must stay stable
+  trailingCommentArg =
+    runCommand /* bash */ "echo hi" # trailing comment
+      A;
 }


### PR DESCRIPTION
When an annotated string headed a function application and was followed by a trailing comment, prettyApp hoisted the string's entire preTrivia (including the language annotation) together with the moved-up trailing comment, rendering `/* bash */ # comment` on one line, which is not a valid language annotation anymore, so on the next pass the annotation would get demoted to a line comment, breaking idempotency.

Now the hoist partitions the trivia: language annotations stay attached to their token and only the other comments are moved above the expression.

This idempotency regression was found by Mic92 in
https://github.com/Mic92/nixfmt-rs/pull/89/changes/a401640a87313109f6bc81193c91e4f342141d2b