### PR TITLE
feat: support chained presence checks (a ? b ? c)

### DIFF
--- a/src/Nixfmt/Parser.hs
+++ b/src/Nixfmt/Parser.hs
@@ -15,6 +15,7 @@ import Data.Bifunctor (second)
 import Data.Char (isAlpha)
 import Data.Foldable (toList)
 import Data.Functor (($>))
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Text (Text, elem, isPrefixOf, pack)
 import Data.Text qualified as Text
@@ -544,9 +545,10 @@ opCombiner (Op Prefix TNot) = chainPrefixOps $ Inversion <$> operator TNot
 opCombiner (Op Prefix _) = undefined
 opCombiner (Op Postfix TQuestion) =
   MPExpr.Postfix $
-    (\question sel expr -> MemberCheck expr question sel)
-      <$> operator TQuestion
-      <*> selectorPath
+    flip MemberCheck
+      <$> ((:|) <$> presenceCheck <*> many presenceCheck)
+  where
+    presenceCheck = (,) <$> operator TQuestion <*> selectorPath
 opCombiner (Op Postfix _) = undefined
 -- HACK: We parse TPlus as left-associative, but convert it to right-associative in the AST
 -- This is allowed because addition is fully associative

--- a/src/Nixfmt/Pretty.hs
+++ b/src/Nixfmt/Pretty.hs
@@ -867,12 +867,12 @@ instance Pretty Expression where
         pretty a <> softline <> pretty op <> hardspace <> pretty b
   -- all other operators
   pretty operation@(Operation _ op _) = prettyOp False operation op
-  pretty (MemberCheck expr qmark sel) =
-    pretty expr
-      <> softline
-      <> pretty qmark
-      <> hardspace
-      <> hcat sel
+  pretty (MemberCheck expr presenceChecks) =
+    group $
+      pretty expr
+        <> nest (foldMap prettyPresenceCheck presenceChecks)
+    where
+      prettyPresenceCheck (qmark, sel) = line <> pretty (moveTrailingCommentUp qmark) <> hardspace <> hcat sel
   pretty (Negation minus expr) =
     pretty minus <> pretty expr
   pretty (Inversion bang expr) =

--- a/src/Nixfmt/Types.hs
+++ b/src/Nixfmt/Types.hs
@@ -45,7 +45,7 @@ module Nixfmt.Types (
 ) where
 
 import Control.Monad.State.Strict (StateT)
-import Data.Bifunctor (first)
+import Data.Bifunctor (Bifunctor (bimap), first)
 import Data.Foldable (toList)
 import Data.Function (on)
 import Data.List.NonEmpty as NonEmpty
@@ -252,7 +252,7 @@ data Expression
   | Abstraction Parameter Leaf Expression
   | Application Expression Expression
   | Operation Expression Leaf Expression
-  | MemberCheck Expression Leaf [Selector]
+  | MemberCheck Expression (NonEmpty (Leaf, [Selector]))
   | Negation Leaf Expression
   | Inversion Leaf Expression
   deriving (Eq, Show)
@@ -456,7 +456,7 @@ instance LanguageElement Expression where
     (Abstraction param colon body) -> first (\param' -> Abstraction param' colon body) (mapFirstToken' f param)
     (Application g a) -> first (`Application` a) (mapFirstToken' f g)
     (Operation left op right) -> first (\left' -> Operation left' op right) (mapFirstToken' f left)
-    (MemberCheck name dot selectors) -> first (\name' -> MemberCheck name' dot selectors) (mapFirstToken' f name)
+    (MemberCheck expr presenceChecks) -> first (`MemberCheck` presenceChecks) (mapFirstToken' f expr)
     (Negation not_ expr) -> first (`Negation` expr) (f not_)
     (Inversion tilde expr) -> first (`Inversion` expr) (f tilde)
 
@@ -469,8 +469,12 @@ instance LanguageElement Expression where
     (Abstraction param colon body) -> first (Abstraction param colon) (mapLastToken' f body)
     (Application g a) -> first (Application g) (mapLastToken' f a)
     (Operation left op right) -> first (Operation left op) (mapLastToken' f right)
-    (MemberCheck name dot []) -> first (\dot' -> MemberCheck name dot' []) (mapLastToken' f dot)
-    (MemberCheck name dot sels) -> first (MemberCheck name dot . NonEmpty.toList) (mapLastToken' f $ NonEmpty.fromList sels)
+    (MemberCheck expr presenceChecks) -> case NonEmpty.last presenceChecks of
+      (qmark, []) -> first (\qmark' -> MemberCheck expr $ replaceLast presenceChecks (qmark', [])) (mapLastToken' f qmark)
+      (qmark, sl) -> first (\selec' -> MemberCheck expr $ replaceLast presenceChecks (qmark, NonEmpty.toList selec')) (mapLastToken' f $ NonEmpty.fromList sl)
+      where
+        -- Replace the last element of a NonEmpty list with a new value
+        replaceLast ne newItem = NonEmpty.fromList (NonEmpty.init ne ++ [newItem])
     (Negation not_ expr) -> first (Negation not_) (mapLastToken' f expr)
     (Inversion tilde expr) -> first (Inversion tilde) (mapLastToken' f expr)
 
@@ -494,7 +498,7 @@ instance LanguageElement Expression where
     (Abstraction param colon@Ann{sourceLine} body) -> [Abstraction param colon (Term (Token (ann sourceLine (Identifier "_")))), body]
     (Application g a) -> [g, a]
     (Operation left _ right) -> [left, right]
-    (MemberCheck name _ sels) -> name : (sels >>= walkSubprograms)
+    (MemberCheck expr presenceChecks) -> expr : foldMap (foldMap walkSubprograms . snd) presenceChecks
     (Negation _ expr) -> [expr]
     (Inversion _ expr) -> [expr]
 
@@ -507,7 +511,7 @@ instance LanguageElement Expression where
     (Abstraction param colon body) -> Abstraction (mapAllTokens f param) (f colon) (mapAllTokens f body)
     (Application g a) -> Application (mapAllTokens f g) (mapAllTokens f a)
     (Operation left op right) -> Operation (mapAllTokens f left) (f op) (mapAllTokens f right)
-    (MemberCheck name dot sels) -> MemberCheck (mapAllTokens f name) (f dot) (Prelude.map (mapAllTokens f) sels)
+    (MemberCheck expr presenceChecks) -> MemberCheck (mapAllTokens f expr) (bimap f (fmap $ mapAllTokens f) <$> presenceChecks)
     (Negation not_ expr) -> Negation (f not_) (mapAllTokens f expr)
     (Inversion tilde expr) -> Inversion (f tilde) (mapAllTokens f expr)
 

--- a/test/diff/directive_edge_cases/in.nix
+++ b/test/diff/directive_edge_cases/in.nix
@@ -35,6 +35,96 @@
 /*nixfmt:enable*/
   ];
 
+  # -- Region closing inside a term --
+  # The cases in this section share byte-identical enabled regions and differ
+  # only inside the disabled region, asserting that a change confined to the
+  # disabled region can change the enabled output. What leaks is the region's
+  # would-be formatted layout, not its raw text: the enabled items shift
+  # exactly when the formatter would have put the bracket on its own line
+  # (blank lines and comments are preserved by formatting, a plain newline
+  # is joined away).
+
+  # Baseline: binding and opening bracket inside the region on one line
+  /*nixfmt:disable*/
+  listOpenInRegion = [
+  /*nixfmt:enable*/
+    "a"
+    "b"
+    "c"
+  ];
+
+  # Bracket on its own raw line: same output as the baseline, because the
+  # formatter would join `= [` back onto one line.
+  /*nixfmt:disable*/
+  listOpenNewline =
+    [
+  /*nixfmt:enable*/
+    "a"
+    "b"
+    "c"
+  ];
+
+  # Differs from listOpenNewline only by the blank line inside the disabled
+  # region, yet the enabled items below are indented one level deeper.
+  /*nixfmt:disable*/
+  listOpenInRegionIndented =
+
+    [
+  /*nixfmt:enable*/
+    "a"
+    "b"
+    "c"
+  ];
+
+  # Differs from listOpenNewline only by the comment inside the disabled
+  # region; the enabled items shift just like with the blank line.
+  /*nixfmt:disable*/
+  listOpenAfterComment = # why
+    [
+  /*nixfmt:enable*/
+    "a"
+    "b"
+    "c"
+  ];
+
+  # Same repro with an attribute set: only the disabled regions differ (a
+  # blank line), yet the enabled bindings change indentation.
+  /*nixfmt:disable*/
+  attrOpenInRegion = {
+  /*nixfmt:enable*/
+    a = 1;
+    b = 2;
+  };
+
+  /*nixfmt:disable*/
+  attrOpenInRegionIndented =
+
+    {
+  /*nixfmt:enable*/
+    a = 1;
+    b = 2;
+  };
+
+  # The canonical use case, a package list behind `with`, repros the same
+  # way. So do parentheses and function application (`mkDerivation {`),
+  # not repeated here: the family is "any opener the formatter would have
+  # absorbed onto the binder's line".
+  /*nixfmt:disable*/
+  withOpenInRegion = with pkgs; [
+  /*nixfmt:enable*/
+    foo
+    bar
+  ];
+
+  /*nixfmt:disable*/
+  withOpenInRegionIndented =
+
+    with pkgs; [
+  /*nixfmt:enable*/
+    foo
+    bar
+  ];
+
   # -- Blank lines --
   # Multiple consecutive blank lines before a directive (should be collapsed)
   beforeBlank   =   1;

--- a/test/diff/directive_edge_cases/out-pure.nix
+++ b/test/diff/directive_edge_cases/out-pure.nix
@@ -40,6 +40,96 @@
 /*nixfmt:enable*/
   ];
 
+  # -- Region closing inside a term --
+  # The cases in this section share byte-identical enabled regions and differ
+  # only inside the disabled region, asserting that a change confined to the
+  # disabled region can change the enabled output. What leaks is the region's
+  # would-be formatted layout, not its raw text: the enabled items shift
+  # exactly when the formatter would have put the bracket on its own line
+  # (blank lines and comments are preserved by formatting, a plain newline
+  # is joined away).
+
+  # Baseline: binding and opening bracket inside the region on one line
+  /*nixfmt:disable*/
+  listOpenInRegion = [
+  /*nixfmt:enable*/
+    "a"
+    "b"
+    "c"
+  ];
+
+  # Bracket on its own raw line: same output as the baseline, because the
+  # formatter would join `= [` back onto one line.
+  /*nixfmt:disable*/
+  listOpenNewline =
+    [
+  /*nixfmt:enable*/
+    "a"
+    "b"
+    "c"
+  ];
+
+  # Differs from listOpenNewline only by the blank line inside the disabled
+  # region, yet the enabled items below are indented one level deeper.
+  /*nixfmt:disable*/
+  listOpenInRegionIndented =
+
+    [
+  /*nixfmt:enable*/
+      "a"
+      "b"
+      "c"
+    ];
+
+  # Differs from listOpenNewline only by the comment inside the disabled
+  # region; the enabled items shift just like with the blank line.
+  /*nixfmt:disable*/
+  listOpenAfterComment = # why
+    [
+  /*nixfmt:enable*/
+      "a"
+      "b"
+      "c"
+    ];
+
+  # Same repro with an attribute set: only the disabled regions differ (a
+  # blank line), yet the enabled bindings change indentation.
+  /*nixfmt:disable*/
+  attrOpenInRegion = {
+  /*nixfmt:enable*/
+    a = 1;
+    b = 2;
+  };
+
+  /*nixfmt:disable*/
+  attrOpenInRegionIndented =
+
+    {
+  /*nixfmt:enable*/
+      a = 1;
+      b = 2;
+    };
+
+  # The canonical use case, a package list behind `with`, repros the same
+  # way. So do parentheses and function application (`mkDerivation {`),
+  # not repeated here: the family is "any opener the formatter would have
+  # absorbed onto the binder's line".
+  /*nixfmt:disable*/
+  withOpenInRegion = with pkgs; [
+  /*nixfmt:enable*/
+    foo
+    bar
+  ];
+
+  /*nixfmt:disable*/
+  withOpenInRegionIndented =
+
+    with pkgs; [
+  /*nixfmt:enable*/
+      foo
+      bar
+    ];
+
   # -- Blank lines --
   # Multiple consecutive blank lines before a directive (should be collapsed)
   beforeBlank = 1;

--- a/test/diff/directive_edge_cases/out.nix
+++ b/test/diff/directive_edge_cases/out.nix
@@ -40,6 +40,96 @@
 /*nixfmt:enable*/
   ];
 
+  # -- Region closing inside a term --
+  # The cases in this section share byte-identical enabled regions and differ
+  # only inside the disabled region, asserting that a change confined to the
+  # disabled region can change the enabled output. What leaks is the region's
+  # would-be formatted layout, not its raw text: the enabled items shift
+  # exactly when the formatter would have put the bracket on its own line
+  # (blank lines and comments are preserved by formatting, a plain newline
+  # is joined away).
+
+  # Baseline: binding and opening bracket inside the region on one line
+  /*nixfmt:disable*/
+  listOpenInRegion = [
+  /*nixfmt:enable*/
+    "a"
+    "b"
+    "c"
+  ];
+
+  # Bracket on its own raw line: same output as the baseline, because the
+  # formatter would join `= [` back onto one line.
+  /*nixfmt:disable*/
+  listOpenNewline =
+    [
+  /*nixfmt:enable*/
+    "a"
+    "b"
+    "c"
+  ];
+
+  # Differs from listOpenNewline only by the blank line inside the disabled
+  # region, yet the enabled items below are indented one level deeper.
+  /*nixfmt:disable*/
+  listOpenInRegionIndented =
+
+    [
+  /*nixfmt:enable*/
+      "a"
+      "b"
+      "c"
+    ];
+
+  # Differs from listOpenNewline only by the comment inside the disabled
+  # region; the enabled items shift just like with the blank line.
+  /*nixfmt:disable*/
+  listOpenAfterComment = # why
+    [
+  /*nixfmt:enable*/
+      "a"
+      "b"
+      "c"
+    ];
+
+  # Same repro with an attribute set: only the disabled regions differ (a
+  # blank line), yet the enabled bindings change indentation.
+  /*nixfmt:disable*/
+  attrOpenInRegion = {
+  /*nixfmt:enable*/
+    a = 1;
+    b = 2;
+  };
+
+  /*nixfmt:disable*/
+  attrOpenInRegionIndented =
+
+    {
+  /*nixfmt:enable*/
+      a = 1;
+      b = 2;
+    };
+
+  # The canonical use case, a package list behind `with`, repros the same
+  # way. So do parentheses and function application (`mkDerivation {`),
+  # not repeated here: the family is "any opener the formatter would have
+  # absorbed onto the binder's line".
+  /*nixfmt:disable*/
+  withOpenInRegion = with pkgs; [
+  /*nixfmt:enable*/
+    foo
+    bar
+  ];
+
+  /*nixfmt:disable*/
+  withOpenInRegionIndented =
+
+    with pkgs; [
+  /*nixfmt:enable*/
+      foo
+      bar
+    ];
+
   # -- Blank lines --
   # Multiple consecutive blank lines before a directive (should be collapsed)
   beforeBlank = 1;

--- a/test/diff/directive_positions/in.nix
+++ b/test/diff/directive_positions/in.nix
@@ -128,6 +128,44 @@
 }:
     a;
 
+  # -- Member check chains --
+
+  # Disabled region around a chained member check is preserved byte-exactly
+/*nixfmt:disable*/
+  chainDisabled = a    ?   b   ?   c;
+/*nixfmt:enable*/
+
+  # Directive sharing a line inside a chain is inert (demoted to a plain comment)
+  chainInert = a ? b /*nixfmt:disable*/ ? c;
+  chainInertAfterQmark = a ?/*nixfmt:disable*/b ? c;
+
+  # Region opening and closing between presence checks.
+  # The unformatted region affects the formatted part of the chain: its hard
+  # line breaks force the whole chain to expand.
+  chainRegionBetween =
+    x ? a
+/*nixfmt:disable*/
+    ?   b   ?   c
+/*nixfmt:enable*/
+    ? d;
+
+  # Region opening mid-chain and closing after the binding.
+  # Same as above: unformatted region affecting the formatted part of the chain.
+  chainRegionAcrossEnd =
+    x ? a
+/*nixfmt:disable*/
+    ?   b   ?   c   ;
+/*nixfmt:enable*/
+
+  # Region opening mid-chain: the part before the directive is still formatted.
+  # Same as above (unformatted region affecting the formatted part), here
+  # leaving a dangling question mark line.
+  chainRegionTail = x    ?   a   ?
+/*nixfmt:disable*/
+    b   ?   c;
+/*nixfmt:enable*/
+  afterChainRegion   =   1;
+
   # -- Directly after a string token --
 
   # The directive must not affect the string preceding it:

--- a/test/diff/directive_positions/out-pure.nix
+++ b/test/diff/directive_positions/out-pure.nix
@@ -144,6 +144,56 @@
     }:
     a;
 
+  # -- Member check chains --
+
+  # Disabled region around a chained member check is preserved byte-exactly
+/*nixfmt:disable*/
+  chainDisabled = a    ?   b   ?   c;
+/*nixfmt:enable*/
+
+  # Directive sharing a line inside a chain is inert (demoted to a plain comment)
+  chainInert =
+    a
+      ? b # nixfmt:disable
+      ? c;
+  chainInertAfterQmark =
+    a
+      # nixfmt:disable
+      ? b
+      ? c;
+
+  # Region opening and closing between presence checks.
+  # The unformatted region affects the formatted part of the chain: its hard
+  # line breaks force the whole chain to expand.
+  chainRegionBetween =
+    x
+      ? a
+/*nixfmt:disable*/
+    ?   b   ?   c
+/*nixfmt:enable*/
+      ? d;
+
+  # Region opening mid-chain and closing after the binding.
+  # Same as above: unformatted region affecting the formatted part of the chain.
+  chainRegionAcrossEnd =
+    x
+      ? a
+/*nixfmt:disable*/
+    ?   b   ?   c   ;
+/*nixfmt:enable*/
+
+  # Region opening mid-chain: the part before the directive is still formatted.
+  # Same as above (unformatted region affecting the formatted part), here
+  # leaving a dangling question mark line.
+  chainRegionTail =
+    x
+      ? a
+      ?
+/*nixfmt:disable*/
+    b   ?   c;
+/*nixfmt:enable*/
+  afterChainRegion = 1;
+
   # -- Directly after a string token --
 
   # The directive must not affect the string preceding it:

--- a/test/diff/directive_positions/out.nix
+++ b/test/diff/directive_positions/out.nix
@@ -144,6 +144,56 @@
     }:
     a;
 
+  # -- Member check chains --
+
+  # Disabled region around a chained member check is preserved byte-exactly
+/*nixfmt:disable*/
+  chainDisabled = a    ?   b   ?   c;
+/*nixfmt:enable*/
+
+  # Directive sharing a line inside a chain is inert (demoted to a plain comment)
+  chainInert =
+    a
+      ? b # nixfmt:disable
+      ? c;
+  chainInertAfterQmark =
+    a
+      # nixfmt:disable
+      ? b
+      ? c;
+
+  # Region opening and closing between presence checks.
+  # The unformatted region affects the formatted part of the chain: its hard
+  # line breaks force the whole chain to expand.
+  chainRegionBetween =
+    x
+      ? a
+/*nixfmt:disable*/
+    ?   b   ?   c
+/*nixfmt:enable*/
+      ? d;
+
+  # Region opening mid-chain and closing after the binding.
+  # Same as above: unformatted region affecting the formatted part of the chain.
+  chainRegionAcrossEnd =
+    x
+      ? a
+/*nixfmt:disable*/
+    ?   b   ?   c   ;
+/*nixfmt:enable*/
+
+  # Region opening mid-chain: the part before the directive is still formatted.
+  # Same as above (unformatted region affecting the formatted part), here
+  # leaving a dangling question mark line.
+  chainRegionTail =
+    x
+      ? a
+      ?
+/*nixfmt:disable*/
+    b   ?   c;
+/*nixfmt:enable*/
+  afterChainRegion = 1;
+
   # -- Directly after a string token --
 
   # The directive must not affect the string preceding it:

--- a/test/diff/language-annotation/in.nix
+++ b/test/diff/language-annotation/in.nix
@@ -173,4 +173,10 @@
   # Same shape with the annotated string as a middle argument must stay stable
   trailingCommentArg = runCommand /*bash*/''echo hi'' # trailing comment
     A;
+
+  # Language annotation on the subject of a chained member check
+  memberCheckSubject = /* lua */ ''print(1)'' ? foo ? bar;
+
+  # Language annotations before quoted selectors in a chained member check
+  memberCheckSelector = a ? b."c" ? /* json */ "d".e ? /* sh */ "f";
 }

--- a/test/diff/language-annotation/out-pure.nix
+++ b/test/diff/language-annotation/out-pure.nix
@@ -191,4 +191,10 @@
   trailingCommentArg =
     runCommand /* bash */ "echo hi" # trailing comment
       A;
+
+  # Language annotation on the subject of a chained member check
+  memberCheckSubject = /* lua */ "print(1)" ? foo ? bar;
+
+  # Language annotations before quoted selectors in a chained member check
+  memberCheckSelector = a ? b."c" ? /* json */ "d".e ? /* sh */ "f";
 }

--- a/test/diff/language-annotation/out.nix
+++ b/test/diff/language-annotation/out.nix
@@ -191,4 +191,10 @@
   trailingCommentArg =
     runCommand /* bash */ "echo hi" # trailing comment
       A;
+
+  # Language annotation on the subject of a chained member check
+  memberCheckSubject = /* lua */ "print(1)" ? foo ? bar;
+
+  # Language annotations before quoted selectors in a chained member check
+  memberCheckSelector = a ? b."c" ? /* json */ "d".e ? /* sh */ "f";
 }

--- a/test/diff/operation/in.nix
+++ b/test/diff/operation/in.nix
@@ -229,4 +229,47 @@
     |> b
     |> c
   )
+
+  # Member checks and chained presence checks
+
+  # Simple member check
+  (a ? b)
+  # Member check with a selector path
+  (a ? b.c.d)
+  # Chained presence checks
+  ({ } ? foo ? bar)
+  ({ } ? a ? b ? null)
+  # Chained presence checks with selector paths and quoted/interpolated selectors
+  (a ? b.c.d ? e."f".${g} ? h.i)
+  (config ? services.nginx.enable ? services.httpd.enable ? false)
+  # Whitespace is normalized
+  (a?b?c?d)
+  (a   ?   b
+     ?   c)
+  # Member check on a selection
+  (a.b ? c ? d)
+  # Parenthesized member check as the left operand
+  ((a ? b) ? c)
+  # Interaction with other operators
+  (a ? b || c ? d ? e)
+  (!(a ? b ? c) && a ? b)
+  (if a ? b ? c then a.b else null)
+  # Chained presence checks in bindings
+  {
+    x = a ? b ? c;
+    y = a ? b ? c; # trailing comment
+  }
+  # A long chain breaks between the presence checks
+  (aaaaaaaaaaaaaaaaaaaaaaaaaa ? bbbbbbbbbbbbbbbbbb ? cccccccccccccccccc ? dddddddddddddddddd ? eeeeeeeeeeeeeeeeee)
+  # A member check that breaks as the operand of an operation that also breaks:
+  # the question mark is indented past the subject
+  (bus_type.name == "PCI" && devices ? "${vendorHex}:${deviceHex}:${subVendorHex}:${subDeviceHex}/${baseClassHex}-${subClassHex}-${revisionHex}")
+  # Comments between presence checks
+  (a # one
+    ? b # two
+    ? c)
+  # Non-empty block comments become line comments (moved above the question mark); empty ones are dropped
+  (a ?/*x*/b.c)
+  (a ? b /*y*/ ? c)
+  (a ?/*x*/b/*y*/? c ?/**/d.e)
 ]

--- a/test/diff/operation/out-pure.nix
+++ b/test/diff/operation/out-pure.nix
@@ -381,4 +381,72 @@
     |> b
     |> c
   )
+
+  # Member checks and chained presence checks
+
+  # Simple member check
+  (a ? b)
+  # Member check with a selector path
+  (a ? b.c.d)
+  # Chained presence checks
+  ({ } ? foo ? bar)
+  ({ } ? a ? b ? null)
+  # Chained presence checks with selector paths and quoted/interpolated selectors
+  (a ? b.c.d ? e."f".${g} ? h.i)
+  (config ? services.nginx.enable ? services.httpd.enable ? false)
+  # Whitespace is normalized
+  (a ? b ? c ? d)
+  (a ? b ? c)
+  # Member check on a selection
+  (a.b ? c ? d)
+  # Parenthesized member check as the left operand
+  ((a ? b) ? c)
+  # Interaction with other operators
+  (a ? b || c ? d ? e)
+  (!(a ? b ? c) && a ? b)
+  (if a ? b ? c then a.b else null)
+  # Chained presence checks in bindings
+  {
+    x = a ? b ? c;
+    y = a ? b ? c; # trailing comment
+  }
+  # A long chain breaks between the presence checks
+  (
+    aaaaaaaaaaaaaaaaaaaaaaaaaa
+      ? bbbbbbbbbbbbbbbbbb
+      ? cccccccccccccccccc
+      ? dddddddddddddddddd
+      ? eeeeeeeeeeeeeeeeee
+  )
+  # A member check that breaks as the operand of an operation that also breaks:
+  # the question mark is indented past the subject
+  (
+    bus_type.name == "PCI"
+    && devices
+      ? "${vendorHex}:${deviceHex}:${subVendorHex}:${subDeviceHex}/${baseClassHex}-${subClassHex}-${revisionHex}"
+  )
+  # Comments between presence checks
+  (
+    a  # one
+      ? b # two
+      ? c
+  )
+  # Non-empty block comments become line comments (moved above the question mark); empty ones are dropped
+  (
+    a
+      # x
+      ? b.c
+  )
+  (
+    a
+      ? b # y
+      ? c
+  )
+  (
+    a
+      # x
+      ? b # y
+      ? c
+      ? d.e
+  )
 ]

--- a/test/diff/operation/out.nix
+++ b/test/diff/operation/out.nix
@@ -383,4 +383,72 @@
     |> b
     |> c
   )
+
+  # Member checks and chained presence checks
+
+  # Simple member check
+  (a ? b)
+  # Member check with a selector path
+  (a ? b.c.d)
+  # Chained presence checks
+  ({ } ? foo ? bar)
+  ({ } ? a ? b ? null)
+  # Chained presence checks with selector paths and quoted/interpolated selectors
+  (a ? b.c.d ? e."f".${g} ? h.i)
+  (config ? services.nginx.enable ? services.httpd.enable ? false)
+  # Whitespace is normalized
+  (a ? b ? c ? d)
+  (a ? b ? c)
+  # Member check on a selection
+  (a.b ? c ? d)
+  # Parenthesized member check as the left operand
+  ((a ? b) ? c)
+  # Interaction with other operators
+  (a ? b || c ? d ? e)
+  (!(a ? b ? c) && a ? b)
+  (if a ? b ? c then a.b else null)
+  # Chained presence checks in bindings
+  {
+    x = a ? b ? c;
+    y = a ? b ? c; # trailing comment
+  }
+  # A long chain breaks between the presence checks
+  (
+    aaaaaaaaaaaaaaaaaaaaaaaaaa
+      ? bbbbbbbbbbbbbbbbbb
+      ? cccccccccccccccccc
+      ? dddddddddddddddddd
+      ? eeeeeeeeeeeeeeeeee
+  )
+  # A member check that breaks as the operand of an operation that also breaks:
+  # the question mark is indented past the subject
+  (
+    bus_type.name == "PCI"
+    && devices
+      ? "${vendorHex}:${deviceHex}:${subVendorHex}:${subDeviceHex}/${baseClassHex}-${subClassHex}-${revisionHex}"
+  )
+  # Comments between presence checks
+  (
+    a  # one
+      ? b # two
+      ? c
+  )
+  # Non-empty block comments become line comments (moved above the question mark); empty ones are dropped
+  (
+    a
+      # x
+      ? b.c
+  )
+  (
+    a
+      ? b # y
+      ? c
+  )
+  (
+    a
+      # x
+      ? b # y
+      ? c
+      ? d.e
+  )
 ]

--- a/test/diff/pattern/in.nix
+++ b/test/diff/pattern/in.nix
@@ -110,6 +110,15 @@
   ({ /*a*/ b /*c*/ , /*d*/ e /*f*/ , /*g*/ ... /*h*/ }: _)
 
   ({ a ? null }: _)
+
+  # Chained presence checks as default values
+  ({ a ? b ? c }: _)
+  ({ a ? b ? c ? d }: _)
+  ({ a ? b.c ? d."e" ? null }: _)
+  ({ foo
+  , bar ? a ? b ? c # comment
+  }: _)
+
   ({ /*a*/ b /*a*/ ? /*a*/ null /*c*/ , /*d*/ e /*a*/ ? /*a*/ null /*f*/ , /*g*/ ... /*h*/ }: _)
 
   ({

--- a/test/diff/pattern/out-pure.nix
+++ b/test/diff/pattern/out-pure.nix
@@ -640,6 +640,34 @@
     }:
     _
   )
+
+  # Chained presence checks as default values
+  (
+    {
+      a ? b ? c,
+    }:
+    _
+  )
+  (
+    {
+      a ? b ? c ? d,
+    }:
+    _
+  )
+  (
+    {
+      a ? b.c ? d."e" ? null,
+    }:
+    _
+  )
+  (
+    {
+      foo,
+      bar ? a ? b ? c, # comment
+    }:
+    _
+  )
+
   (
     # a
     {

--- a/test/diff/pattern/out.nix
+++ b/test/diff/pattern/out.nix
@@ -640,6 +640,34 @@
     }:
     _
   )
+
+  # Chained presence checks as default values
+  (
+    {
+      a ? b ? c,
+    }:
+    _
+  )
+  (
+    {
+      a ? b ? c ? d,
+    }:
+    _
+  )
+  (
+    {
+      a ? b.c ? d."e" ? null,
+    }:
+    _
+  )
+  (
+    {
+      foo,
+      bar ? a ? b ? c, # comment
+    }:
+    _
+  )
+
   (
     # a
     {


### PR DESCRIPTION
Allow the ? operator to chain: a member check can now be followed by further `? selector.path` operations, e.g. `{} ? foo ? bar ? null`. Previously the operator accepted a single selector path and a chain was a parse error.

> [!CAUTION]
> Be aware that this syntax is never useful in practice: it parses left-associatively as `(a ? b) ? c`, so the first check yields a boolean and each further check tests an attribute on that boolean, making any chain of **two or more `?` evaluate to constant false**. It is valid Nix syntax nonetheless, so the formatter handles it for correctness.

MemberCheck now carries a non-empty list of (question mark, selector path) pairs instead of a single pair. A chain stays on one line when it fits; otherwise it breaks before every question mark, indented one level past the subject:

```nix
  aaaaaaaaaaaaaaaaaaaaaaaaaa
    ? bbbbbbbbbbbbbbbbbb
    ? cccccccccccccccccc
```

Like other operators, a comment trailing a question mark is moved onto its own line above it, keeping the question mark attached to its selector path.

closes #359