### PR TITLE
chore: adopt the GHC2024 language edition

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Main where
@@ -17,10 +14,10 @@ import Data.FileEmbed
 import Data.List (intersperse, isSuffixOf)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import qualified Data.Text.IO as TextIO (getContents, hPutStr, putStr)
+import Data.Text.IO qualified as TextIO (getContents, hPutStr, putStr)
 import Data.Version (showVersion)
 import GHC.IO.Encoding (utf8)
-import qualified Nixfmt
+import Nixfmt qualified
 import Nixfmt.Predoc (layout)
 import Paths_nixfmt (version)
 import System.Console.CmdArgs (

--- a/main/System/IO/Utf8.hs
+++ b/main/System/IO/Utf8.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -- | Helpers for implementing tools that process UTF-8 encoded data.
@@ -24,10 +23,10 @@ where
 
 import Control.Exception (bracket)
 import Data.Text (Text)
-import qualified Data.Text.IO as T
+import Data.Text.IO qualified as T
 import GHC.IO.Encoding (mkTextEncoding, textEncodingName, utf8)
 import System.IO (stderr, stdin, stdout)
-import qualified System.IO as IO
+import System.IO qualified as IO
 
 type EncRestoreAction = IO.Handle -> IO ()
 

--- a/nixfmt.cabal
+++ b/nixfmt.cabal
@@ -54,10 +54,13 @@ executable nixfmt
     System.IO.Atomic
   autogen-modules:
     Paths_nixfmt
-  other-extensions:    DeriveDataTypeable
+  other-extensions:
+    MultiWayIf
+    TemplateHaskell
+    ViewPatterns
   hs-source-dirs:      main
   build-depends:
-      base             >= 4.12.0
+      base             >= 4.20.0
     , bytestring
     , cmdargs          >= 0.10.20
     , file-embed
@@ -71,7 +74,7 @@ executable nixfmt
     , directory        >= 1.3.3
     , filepath         >= 1.4.2
     , safe-exceptions  >= 0.1.7
-  default-language:    Haskell2010
+  default-language:    GHC2024
   ghc-options:
     -threaded
 
@@ -92,18 +95,15 @@ library
     PackageImports
 
   other-extensions:
-    DeriveFoldable
-    DeriveFunctor
-    FlexibleInstances
-    LambdaCase
+    BlockArguments
+    OverloadedLists
     OverloadedStrings
-    ScopedTypeVariables
-    StandaloneDeriving
-    TupleSections
+    PatternSynonyms
+    StrictData
 
   hs-source-dirs:      src
   build-depends:
-      base             >= 4.12.0
+      base             >= 4.20.0
     , containers
     , megaparsec       >= 9.0.1
     , mtl
@@ -112,4 +112,4 @@ library
     , text             >= 1.2.3
     , transformers
     , pretty-simple
-  default-language:    Haskell2010
+  default-language:    GHC2024

--- a/src/Nixfmt.hs
+++ b/src/Nixfmt.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedLists #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Nixfmt (
   errorBundlePretty,
@@ -16,11 +15,11 @@ import Data.Bifunctor (bimap, first)
 import Data.Either (fromRight)
 import Data.Text (Text, unpack)
 import Data.Text.Lazy (toStrict)
-import qualified Nixfmt.Parser as Parser
+import Nixfmt.Parser qualified as Parser
 import Nixfmt.Predoc (Pretty, fixup, pretty)
 import Nixfmt.Pretty ()
 import Nixfmt.Types (Expression, LanguageElement, ParseErrorBundle, Whole (..), walkSubprograms)
-import qualified Text.Megaparsec as Megaparsec (parse)
+import Text.Megaparsec qualified as Megaparsec (parse)
 import Text.Megaparsec.Error (errorBundlePretty)
 import Text.Pretty.Simple (pShow)
 

--- a/src/Nixfmt/Lexer.hs
+++ b/src/Nixfmt/Lexer.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Nixfmt.Lexer (lexeme, pushTrivia, takeTrivia, whole, wholeInner) where
 

--- a/src/Nixfmt/Parser.hs
+++ b/src/Nixfmt/Parser.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -8,7 +6,7 @@ module Nixfmt.Parser where
 
 import Control.Monad (guard, liftM2, (<$!>))
 import Control.Monad.Combinators (sepBy)
-import qualified Control.Monad.Combinators.Expr as MPExpr (
+import Control.Monad.Combinators.Expr qualified as MPExpr (
   Operator (..),
   makeExprParser,
  )
@@ -19,7 +17,7 @@ import Data.Foldable (toList)
 import Data.Functor (($>))
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Text (Text, elem, isPrefixOf, pack)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Void (Void)
 import Nixfmt.Lexer (lexeme, takeTrivia, whole, wholeInner)
 import Nixfmt.Parser.Float (floatParse)

--- a/src/Nixfmt/Parser/Float.hs
+++ b/src/Nixfmt/Parser/Float.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE TypeOperators #-}
-
 module Nixfmt.Parser.Float (floatParse) where
 
 import Data.List (singleton)

--- a/src/Nixfmt/Predoc.hs
+++ b/src/Nixfmt/Predoc.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StrictData #-}
 
@@ -48,9 +45,9 @@ import Data.Functor (($>), (<&>))
 import Data.Functor.Identity (runIdentity)
 import Data.List (intersperse)
 import Data.List.NonEmpty (NonEmpty (..), singleton, (<|))
-import qualified Data.List.NonEmpty as NonEmpty
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (fromMaybe)
-import qualified Data.Sequence as Seq
+import Data.Sequence qualified as Seq
 import Data.Text as Text (Text, concat, length, replicate, strip, stripStart, takeWhileEnd)
 import GHC.Stack (HasCallStack)
 import Nixfmt.Types (

--- a/src/Nixfmt/Pretty.hs
+++ b/src/Nixfmt/Pretty.hs
@@ -1,20 +1,13 @@
-{-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TupleSections #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Nixfmt.Pretty where
 
 import Data.Char (isSpace)
 import Data.Maybe (fromJust, fromMaybe, isJust, isNothing)
-import qualified Data.Sequence as Seq
+import Data.Sequence qualified as Seq
 import Data.Text (Text)
-import qualified Data.Text as Text (null, span, takeWhile)
+import Data.Text qualified as Text (null, span, takeWhile)
 import Nixfmt.Predoc (
   Doc,
   GroupAnn (..),

--- a/src/Nixfmt/Types.hs
+++ b/src/Nixfmt/Types.hs
@@ -1,12 +1,6 @@
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StrictData #-}
 
 module Nixfmt.Types (
@@ -60,7 +54,7 @@ import Data.Sequence
 import Data.Text (Text)
 import Data.Void (Void)
 import Text.Megaparsec (Pos)
-import qualified Text.Megaparsec as MP (ParseErrorBundle, Parsec, pos1)
+import Text.Megaparsec qualified as MP (ParseErrorBundle, Parsec, pos1)
 import Prelude hiding (String)
 
 -- | State threaded through the parser.


### PR DESCRIPTION
Switch default-language from Haskell2010 to GHC2024 and delete the per-file LANGUAGE pragmas the edition subsumes, along with an unused BlockArguments pragma in Nixfmt.Lexer, going from 46 pragma lines to 17. The remaining pragmas are the extensions outside the edition.

Formatting changes to qualified imports are fourmolu adapting to the upgrade.

Also:

- Update the stale other-extensions lists.
- Raise base to 4.20, since GHC2024 requires GHC 9.10.